### PR TITLE
Silence warning for resource leak

### DIFF
--- a/tests/docker/test_async_docker_client.py
+++ b/tests/docker/test_async_docker_client.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from tornado.testing import AsyncTestCase, gen_test
 
 from remoteappmanager.docker.async_docker_client import AsyncDockerClient
@@ -7,6 +8,22 @@ from tests import utils
 
 
 class TestAsyncDockerClient(AsyncTestCase):
+    def setUp(self):
+        super().setUp()
+        # Due to a python requests design choice, we receive a warning about
+        # leaking connection. This is expected and pretty much out of our
+        # authority but it can be annoying in tests, hence we suppress the
+        # warning. See issue simphony-remote/10
+        warnings.filterwarnings(action="ignore",
+                                message="unclosed",
+                                category=ResourceWarning)
+
+    def tearDown(self):
+        super().tearDown()
+        warnings.filterwarnings(action="default",
+                                message="unclosed",
+                                category=ResourceWarning)
+
     @gen_test
     def test_info(self):
         client = AsyncDockerClient()


### PR DESCRIPTION
Fixes a warning due to a python request resource leak (from connectionpool
being GC before being cleaned up). This seems to be a request issue and I am
unsure we can do anything on our side. This PR simply silences the warning.

See https://github.com/kennethreitz/requests/issues/1882
for details about the issue itself.