### PR TITLE
Check if volume source exists in ContainerManager

### DIFF
--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -174,7 +174,7 @@ class ContainerManager(LoggingMixin):
         volume_targets = [binding['bind']
                           for binding in filtered_volumes.values()]
 
-        # Log the paths that are being mounted
+        # Log the paths that are not being mounted
         if volumes.keys() - filtered_volumes.keys():
             self.log.error('Path(s) does not exist, not mounting:\n%s',
                            '\n'.join(volumes.keys() - filtered_volumes.keys()))

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -162,6 +162,8 @@ class ContainerManager(LoggingMixin):
         # Data volume binding to be used with Docker Client
         # volumes = {volume_source: {'bind': volume_target,
         #                            'mode': volume_mode}
+        volumes = volumes if volumes else {}
+
         # Filter away the volume sources that do not exist,
         # otherwise Docker would create non-existing host directory
         # See Docker PR #21666

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -1,3 +1,4 @@
+import os
 import string
 from urllib.parse import urlparse
 
@@ -161,9 +162,20 @@ class ContainerManager(LoggingMixin):
         # Data volume binding to be used with Docker Client
         # volumes = {volume_source: {'bind': volume_target,
         #                            'mode': volume_mode}
-        volumes = volumes if volumes else {}
+        # Filter away the volume sources that do not exist,
+        # otherwise Docker would create non-existing host directory
+        # See Docker PR #21666
+        filtered_volumes = {source: volumes[source]
+                            for source in volumes
+                            if os.path.exists(source)}
+
         volume_targets = [binding['bind']
-                          for binding in volumes.values()]
+                          for binding in filtered_volumes.values()]
+
+        # Log the paths that are being mounted
+        if volumes.keys() - filtered_volumes.keys():
+            self.log.error('Path(s) does not exist, not mounting:\n%s',
+                           '\n'.join(volumes.keys() - filtered_volumes.keys()))
 
         create_kwargs = dict(
             image=image_name,
@@ -177,7 +189,7 @@ class ContainerManager(LoggingMixin):
             port_bindings={
                 self.container_port: None
             },
-            binds=volumes
+            binds=filtered_volumes
         )
 
         self.log.debug("Starting host with config: %s", host_config)

--- a/remoteappmanager/handlers/home_handler.py
+++ b/remoteappmanager/handlers/home_handler.py
@@ -157,13 +157,7 @@ class HomeHandler(BaseHandler):
 
         if allow_home:
             home_path = os.path.expanduser('~'+user_name)
-
-            if os.path.exists(home_path):
-                volumes[home_path] = {'bind': '/workspace', 'mode': 'rw'}
-
-            else:
-                message = ('{home_path} is not available. Not mounting it.')
-                self.log.error(message.format(home_path=home_path))
+            volumes[home_path] = {'bind': '/workspace', 'mode': 'rw'}
 
         # FIXME: Should retrieve allow_common and app from the database
         allow_common = True
@@ -174,12 +168,8 @@ class HomeHandler(BaseHandler):
                                         mode='ro'))
 
         if allow_common:
-            if os.path.exists(app.volume.source):
-                volumes[app.volume.source] = {'bind': app.volume.target,
-                                              'mode': app.volume.mode}
-            else:
-                self.log.error('%s does not exist, not mounting it',
-                               app.volume.source)
+            volumes[app.volume.source] = {'bind': app.volume.target,
+                                          'mode': app.volume.mode}
 
         try:
             f = manager.start_container(user_name, image_name, volumes)

--- a/tests/docker/test_container_manager.py
+++ b/tests/docker/test_container_manager.py
@@ -1,3 +1,5 @@
+import os
+
 from remoteappmanager.docker.container import Container
 from remoteappmanager.docker.container_manager import ContainerManager
 from tests import utils
@@ -82,3 +84,29 @@ class TestContainerManager(AsyncTestCase):
         # Stop should have been called and the container removed
         self.assertTrue(mock_client.stop.called)
         self.assertTrue(mock_client.remove_container.called)
+
+    @gen_test
+    def test_start_container_with_nonexisting_volume_source(self):
+        # These volume sources are invalid
+        volumes = {'~no_way_this_be_valid': {'bind': '/target_vol1',
+                                             'mode': 'ro'},
+                   '/no_way_this_be_valid': {'bind': '/target_vol2',
+                                             'mode': 'ro'}}
+
+        # This volume source is valid
+        good_path = os.path.abspath('.')
+        volumes[good_path] = {'bind': '/target_vol3',
+                              'mode': 'ro'}
+
+        yield self.manager.start_container("username", "imageid", volumes)
+
+        # Call args and keyword args that craete_container receives
+        args = self.manager.docker_client.client.create_container.call_args
+        actual_volume_targets = args[1]['volumes']
+
+        # Invalid volume paths should have been filtered away
+        self.assertNotIn('/target_vol1', actual_volume_targets)
+        self.assertNotIn('/target_vol2', actual_volume_targets)
+
+        # Home directory is valid, should stay
+        self.assertIn('/target_vol3', actual_volume_targets)

--- a/tests/docker/test_container_manager.py
+++ b/tests/docker/test_container_manager.py
@@ -100,7 +100,7 @@ class TestContainerManager(AsyncTestCase):
 
         yield self.manager.start_container("username", "imageid", volumes)
 
-        # Call args and keyword args that craete_container receives
+        # Call args and keyword args that create_container receives
         args = self.manager.docker_client.client.create_container.call_args
         actual_volume_targets = args[1]['volumes']
 

--- a/tests/docker/test_container_manager.py
+++ b/tests/docker/test_container_manager.py
@@ -108,5 +108,5 @@ class TestContainerManager(AsyncTestCase):
         self.assertNotIn('/target_vol1', actual_volume_targets)
         self.assertNotIn('/target_vol2', actual_volume_targets)
 
-        # Home directory is valid, should stay
+        # The current directory is valid, should stay
         self.assertIn('/target_vol3', actual_volume_targets)


### PR DESCRIPTION
The checking for whether a volume source path exists should occur in the ContainerManager._start_container

Refactoring following #2 

This simplifies HomeHandler and makes it easier to test.
