### PR TITLE
Replaced URL identifier from container id to uuid

### DIFF
--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -25,10 +25,13 @@ class Container(HasTraits):
     #: ...and port where the container service will be listening
     port = Int()
 
+    #: the id that will go in the URL of the container
+    url_id = Unicode()
+
     @property
     def url(self):
         """Returns the relative url of the Container."""
-        return "containers/{}".format(self.docker_id)
+        return "containers/{}".format(self.url_id)
 
     @property
     def host_url(self):

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -456,6 +456,7 @@ def _generate_container_name(prefix, user_name, image_name):
 
 
 def _generate_container_url_id():
+    """Generates a unique string to identify the container through a url"""
     return uuid.uuid4().hex
 
 

--- a/tests/docker/test_container.py
+++ b/tests/docker/test_container.py
@@ -6,7 +6,7 @@ from remoteappmanager.docker.container import Container
 class TestContainer(TestCase):
     def test_url(self):
         container = Container(
-            docker_id="12345"
+            url_id="12345"
         )
 
         self.assertEqual(container.url, "containers/12345")

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -42,7 +42,7 @@ class TestApplication(testing.AsyncTestCase):
 
     def test_container_url_abspath(self):
         app = self.app
-        container = Container(docker_id="12345")
+        container = Container(url_id="12345")
         abspath = app.container_url_abspath(container)
         self.assertEqual(abspath, "/testing/containers/12345")
 


### PR DESCRIPTION
Passes an appropriate hex string to identify the container, instead of the container ID.
Requires appropriate change in the containers.