### PR TITLE
Feature: UI reaction to failure to start containers

### DIFF
--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -23,7 +23,7 @@ class Container(HasTraits):
     ip = Unicode()
 
     #: ...and port where the container service will be listening
-    port = Int()
+    port = Int(None, allow_none=True)
 
     @property
     def url(self):
@@ -38,3 +38,41 @@ class Container(HasTraits):
             ip=self.ip,
             port=self.port,
         )
+
+    def __repr__(self):
+        return ('<Container(docker_id={0}, name={1}, image_name={2}, '
+                'image_id={3}, ip={4}, port={5}>').format(
+                    self.docker_id, self.name,
+                    self.image_name, self.image_id,
+                    self.ip, self.port)
+
+    @classmethod
+    def from_docker_dict(cls, docker_dict):
+        """Returns a Container object with the info given by a
+        docker Client.
+
+        Parameters
+        ----------
+        docker_dict : dict
+            One item from the result of docker.Client.containers
+
+        Returns
+        -------
+        container : Container
+
+        Examples
+        --------
+        >>> # containers is a list of dict
+        >>> containers = docker.Client().containers()
+
+        >>> Container.from_docker_dict(containers[0])
+        """
+        if docker_dict.get('Ports'):
+            ip = docker_dict['Ports'][0].get('IP', "")
+            port = docker_dict['Ports'][0].get('PublicPort')
+
+        return cls(docker_id=docker_dict.get('Id', ''),
+                   name=docker_dict.get('Names', ('',))[0],
+                   image_name=docker_dict.get('Image', ''),
+                   image_id=docker_dict.get('ImageID', ''),
+                   ip=ip, port=port)

--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -70,6 +70,9 @@ class Container(HasTraits):
         if docker_dict.get('Ports'):
             ip = docker_dict['Ports'][0].get('IP', "")
             port = docker_dict['Ports'][0].get('PublicPort')
+        else:
+            ip = ""
+            port = None
 
         return cls(docker_id=docker_dict.get('Id', ''),
                    name=docker_dict.get('Names', ('',))[0],

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -92,26 +92,44 @@ class ContainerManager(LoggingMixin):
             self._stop_pending.remove(container_id)
 
     @gen.coroutine
-    def containers_for_image(self, image_id):
-        """Returns the containers for a given image that are managed
-        by this object.
+    def containers_for_image(self, image_id_or_name, user_name=None):
+        """Returns the currently running containers for a given image.
+
+        If `user_name` is given, only returns containers started by the
+        given user name.
 
         It is a coroutine because we might want to run an inquire to the docker
         service if not present.
 
         Parameters
         ----------
-        image_id: str
-            The image id
+        image_id_or_name: str
+            The image id or name
+
+        Optional parameters
+        -------------------
+        user_name : str
+            Name of the user who started the container
 
         Return
         ------
         A list of container objects, or an empty list if not present.
         """
-        try:
-            return self._containers_for_image[image_id]
-        except KeyError:
-            return []
+        if user_name:
+            user_labels = _get_container_labels(user_name)
+            if user_labels:
+                filters = {'label': '{0}={1}'.format(*user_labels.popitem())}
+        else:
+            filters = {}
+
+        filters['ancestor'] = image_id_or_name
+
+        containers = yield self.docker_client.containers(filters=filters)
+        return [Container.from_docker_dict(container)
+                for container in containers
+                # Require further filtering as ancestor include grandparents
+                if (container.get('Image') == image_id_or_name or
+                    container.get('ImageID') == image_id_or_name)]
 
     @gen.coroutine
     def all_images(self):

--- a/remoteappmanager/handlers/home_handler.py
+++ b/remoteappmanager/handlers/home_handler.py
@@ -79,7 +79,8 @@ class HomeHandler(BaseHandler):
 
             # Render the home page again with the error message
             # User-facing error message (less info)
-            message = ('Failed to {action} "{image_name}". Reason: {error_type} '
+            message = ('Failed to {action} "{image_name}". '
+                       'Reason: {error_type} '
                        '(Ref: {ref})')
             self.render('home.html', images_info=images_info,
                         error_message=message.format(

--- a/tests/docker/test_container.py
+++ b/tests/docker/test_container.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from remoteappmanager.docker.container import Container
+from tests.utils import assert_containers_equal
 
 
 class TestContainer(TestCase):
@@ -18,3 +19,64 @@ class TestContainer(TestCase):
         )
 
         self.assertEqual(container.host_url, "http://123.45.67.89:31337")
+
+    def test_from_docker_dict_with_public_port(self):
+        '''Test convertion from "docker ps" to Container with public port'''
+        # With public port
+        container_dict = {
+            'Command': '/startup.sh',
+            'Created': 1466756760,
+            'HostConfig': {'NetworkMode': 'default'},
+            'Id': '248e45e717cd740ae763a1c565',
+            'Image': 'empty-ubuntu:latest',
+            'ImageID': 'sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
+            'Labels': {'eu.simphony-project.docker.ui_name': 'Empty Ubuntu',
+                       'eu.simphony-project.docker.user': 'user'},
+            'Names': ['/remoteexec-user-empty-ubuntu_3Alatest'],
+            'Ports': [{'IP': '0.0.0.0',
+                       'PrivatePort': 8888,
+                       'PublicPort': 32823,
+                       'Type': 'tcp'}],
+            'State': 'running',
+            'Status': 'Up 56 minutes'}
+
+        # Container with public port
+        actual = Container.from_docker_dict(container_dict)
+        expected = Container(
+            docker_id='248e45e717cd740ae763a1c565',
+            name='/remoteexec-user-empty-ubuntu_3Alatest',
+            image_name='empty-ubuntu:latest',
+            image_id='sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
+            ip='0.0.0.0', port=32823)
+
+        assert_containers_equal(self, actual, expected)
+
+    def test_from_docker_dict_without_public_port(self):
+        '''Test convertion from "docker ps" to Container with public port'''
+        # With public port
+        container_dict = {
+            'Command': '/startup.sh',
+            'Created': 1466756760,
+            'HostConfig': {'NetworkMode': 'default'},
+            'Id': '812c765d0549be0ab831ae8348',
+            'Image': 'novnc-ubuntu:latest',
+            'ImageID': 'sha256:f4610c75d3c0dfa25d3c0dfa25d3c0dfa2',
+            'Labels': {'eu.simphony-project.docker.ui_name': 'Empty Ubuntu',
+                       'eu.simphony-project.docker.user': 'user'},
+            'Names': ['/remoteexec-user-empty-ubuntu_3Alatest'],
+            'Ports': [{'IP': '0.0.0.0',
+                       'PrivatePort': 8888,
+                       'Type': 'tcp'}],
+            'State': 'running',
+            'Status': 'Up 56 minutes'}
+
+        # Container without public port
+        actual = Container.from_docker_dict(container_dict)
+        expected = Container(
+            docker_id='812c765d0549be0ab831ae8348',
+            name='/remoteexec-user-empty-ubuntu_3Alatest',
+            image_name='novnc-ubuntu:latest',
+            image_id='sha256:f4610c75d3c0dfa25d3c0dfa25d3c0dfa2',
+            ip='0.0.0.0', port=None)
+
+        assert_containers_equal(self, actual, expected)

--- a/tests/docker/test_container_manager.py
+++ b/tests/docker/test_container_manager.py
@@ -31,19 +31,22 @@ class TestContainerManager(AsyncTestCase):
         self.assertTrue(mock_client.remove_container.called)
 
     @gen_test
-    def test_container_for_image(self):
-        mock_docker_client = utils.mock_docker_client_with_running_containers()  # noqa
-        self.mock_docker_client = mock_docker_client
-        self.manager.docker_client.client = mock_docker_client
+    def test_containers_for_image_results(self):
+        ''' Test containers_for_image returns a list of Container '''
+        # The mock client mocks the output of docker Client.containers
+        docker_client = utils.mock_docker_client_with_running_containers()
+        self.mock_docker_client = docker_client
+        self.manager.docker_client.client = docker_client
 
+        # The output should be a list of Container
         results = yield self.manager.containers_for_image("imageid")
         expected = [Container(docker_id='someid',
                               name='/remoteexec-image_3Alatest_user',
-                              image_name='quay.io/travisci/travis-python:latest',  # noqa
+                              image_name='simphony/mayavi-4.4.4:latest',  # noqa
                               image_id='imageid', ip='0.0.0.0', port=None),
                     Container(docker_id='someid',
                               name='/remoteexec-image_3Alatest_user2',
-                              image_name='quay.io/travisci/travis-python:latest',  # noqa
+                              image_name='simphony/mayavi-4.4.4:latest',  # noqa
                               image_id='imageid', ip='0.0.0.0', port=None)]
         for result, expected_container in zip(results, expected):
             utils.assert_containers_equal(self, result, expected_container)

--- a/tests/docker/test_container_manager.py
+++ b/tests/docker/test_container_manager.py
@@ -49,7 +49,11 @@ class TestContainerManager(AsyncTestCase):
                     Container(docker_id='someid',
                               name='/remoteexec-image_3Alatest_user2',
                               image_name='simphony/mayavi-4.4.4:latest',  # noqa
-                              image_id='imageid', ip='0.0.0.0', port=None)]
+                              image_id='imageid', ip='0.0.0.0', port=None),
+                    Container(docker_id='someid',
+                              name='/remoteexec-image_3Alatest_user3',
+                              image_name='simphony/mayavi-4.4.4:latest',  # noqa
+                              image_id='imageid', ip='', port=None)]
 
         for result, expected_container in zip(results, expected):
             utils.assert_containers_equal(self, result, expected_container)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,8 +48,8 @@ def mock_docker_client():
 
 
 def mock_docker_client_with_running_containers():
-    """Same as above, but it behaves as if one of the containers is already
-    started."""
+    """Same as above, but it behaves as if one of the images have two
+    containers running for different users."""
     client = mock_docker_client()
     client.containers.return_value = [
         # user
@@ -57,7 +57,7 @@ def mock_docker_client_with_running_containers():
          'Created': 1466766499,
          'HostConfig': {'NetworkMode': 'default'},
          'Id': 'someid',
-         'Image': 'quay.io/travisci/travis-python:latest',
+         'Image': 'simphony/mayavi-4.4.4:latest',
          'ImageID': 'imageid',
          'Labels': {'eu.simphony-project.docker.user': 'user'},
          'Names': ['/remoteexec-image_3Alatest_user'],
@@ -72,7 +72,7 @@ def mock_docker_client_with_running_containers():
          'Created': 1466766499,
          'HostConfig': {'NetworkMode': 'default'},
          'Id': 'someid',
-         'Image': 'quay.io/travisci/travis-python:latest',
+         'Image': 'simphony/mayavi-4.4.4:latest',
          'ImageID': 'imageid',
          'Labels': {'eu.simphony-project.docker.user': 'user2'},
          'Names': ['/remoteexec-image_3Alatest_user2'],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,6 +81,17 @@ def mock_docker_client_with_running_containers():
                     'PrivatePort': 22,
                     'Type': 'tcp'}],
          'State': 'running',
+         'Status': 'Up About an hour'},
+        # user3 (somehow there is no port
+        {'Command': '/sbin/init -D',
+         'Created': 1466766499,
+         'HostConfig': {'NetworkMode': 'default'},
+         'Id': 'someid',
+         'Image': 'simphony/mayavi-4.4.4:latest',
+         'ImageID': 'imageid',
+         'Labels': {'eu.simphony-project.docker.user': 'user3'},
+         'Names': ['/remoteexec-image_3Alatest_user3'],
+         'State': 'running',
          'Status': 'Up About an hour'}]
 
     return client

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,6 +47,45 @@ def mock_docker_client():
     return docker_client
 
 
+def mock_docker_client_with_running_containers():
+    """Same as above, but it behaves as if one of the containers is already
+    started."""
+    client = mock_docker_client()
+    client.containers.return_value = [
+        # user
+        {'Command': '/sbin/init -D',
+         'Created': 1466766499,
+         'HostConfig': {'NetworkMode': 'default'},
+         'Id': 'someid',
+         'Image': 'quay.io/travisci/travis-python:latest',
+         'ImageID': 'imageid',
+         'Labels': {'eu.simphony-project.docker.user': 'user'},
+         'Names': ['/remoteexec-image_3Alatest_user'],
+         'Ports': [{'IP': '0.0.0.0',
+                    'PublicIP': 34567,
+                    'PrivatePort': 22,
+                    'Type': 'tcp'}],
+         'State': 'running',
+         'Status': 'Up About an hour'},
+        # user2
+        {'Command': '/sbin/init -D',
+         'Created': 1466766499,
+         'HostConfig': {'NetworkMode': 'default'},
+         'Id': 'someid',
+         'Image': 'quay.io/travisci/travis-python:latest',
+         'ImageID': 'imageid',
+         'Labels': {'eu.simphony-project.docker.user': 'user2'},
+         'Names': ['/remoteexec-image_3Alatest_user2'],
+         'Ports': [{'IP': '0.0.0.0',
+                    'PublicIP': 34567,
+                    'PrivatePort': 22,
+                    'Type': 'tcp'}],
+         'State': 'running',
+         'Status': 'Up About an hour'}]
+
+    return client
+
+
 def mock_docker_client_with_existing_stopped_container():
     """Same as above, but it behaves as if one of the containers is already
     started."""
@@ -167,3 +206,14 @@ def invocation_argv():
     yield
 
     sys.argv[:] = saved_argv
+
+
+def assert_containers_equal(test_case, actual, expected):
+    if (expected.docker_id != actual.docker_id or
+            expected.name != actual.name or
+            expected.image_name != actual.image_name or
+            expected.image_id != actual.image_id or
+            expected.ip != actual.ip or
+            expected.port != actual.port):
+        message = '{!r} is not identical to the expected {!r}'
+        test_case.fail(message.format(actual, expected))


### PR DESCRIPTION
Fixes #14 #15 and provides #6 

- `ContainerManager.containers_for_image` returns a list of Container (as before) using docker Client API instead of the cached dictionary
- Refactor the error message for `HomeHandler._actionhandler_*` to `HomeHandler.post`
- Always clean up started container in something fails in _actionhandler
