### PR TITLE
Feature adapt database interface

### DIFF
--- a/remoteappmanager/application.py
+++ b/remoteappmanager/application.py
@@ -2,7 +2,6 @@ import os
 from urllib import parse
 
 from traitlets import Instance
-from sqlalchemy.orm.exc import MultipleResultsFound
 from tornado import web, gen
 import tornado.ioloop
 from jinja2 import Environment, FileSystemLoader

--- a/remoteappmanager/application.py
+++ b/remoteappmanager/application.py
@@ -206,7 +206,7 @@ class Application(web.Application, LoggingMixin):
 
     def _db_init(self):
         """Initializes the database connection."""
-        self.db = orm.Database(self.file_config.db_url)
+        self.db = orm.AccountingInterface(self.file_config.db_url)
 
     def _user_init(self):
         """Initializes the user at the database level."""

--- a/remoteappmanager/application.py
+++ b/remoteappmanager/application.py
@@ -205,7 +205,7 @@ class Application(web.Application, LoggingMixin):
 
     def _db_init(self):
         """Initializes the database connection."""
-        self.db = orm.AccountingInterface(self.file_config.db_url)
+        self.db = orm.AppAccounting(self.file_config.db_url)
 
     def _user_init(self):
         """Initializes the user at the database level."""

--- a/remoteappmanager/db/orm.py
+++ b/remoteappmanager/db/orm.py
@@ -130,7 +130,7 @@ class Database(LoggingMixin):
         Base.metadata.create_all(self.engine)
 
 
-class AccountingInterface(ABCAccounting):
+class AppAccounting(ABCAccounting):
 
     def __init__(self, url, **kwargs):
         self.db = Database(url, **kwargs)

--- a/remoteappmanager/handlers/home_handler.py
+++ b/remoteappmanager/handlers/home_handler.py
@@ -240,13 +240,13 @@ class HomeHandler(BaseHandler):
 
         Parameters
         ----------
-        orm_user : orm.User
-            the orm user object
+        orm_user : User
+            database's user object (e.g. current_user.orm_user)
 
-        app : orm.Application
+        app : ABCApplication
             the application to start
 
-        policy : orm.ApplicationPolicy
+        policy : ABCApplicationPolicy
             The startup policy for the application
         """
 

--- a/remoteappmanager/handlers/home_handler.py
+++ b/remoteappmanager/handlers/home_handler.py
@@ -231,6 +231,8 @@ class HomeHandler(BaseHandler):
             )
             return None
 
+    # FIXME: The orm_user here requires any database implementation
+    # to provide a user object with a name attribute
     @gen.coroutine
     def _start_container(self, orm_user, app, policy, mapping_id):
         """Start the container. This method is a helper method that

--- a/remoteappmanager/handlers/home_handler.py
+++ b/remoteappmanager/handlers/home_handler.py
@@ -11,7 +11,6 @@ from tornado.log import app_log
 
 from remoteappmanager.handlers.base_handler import BaseHandler
 from remoteappmanager.docker.container import Container
-from remoteappmanager.db import orm
 
 
 class HomeHandler(BaseHandler):

--- a/remoteappmanager/user.py
+++ b/remoteappmanager/user.py
@@ -1,6 +1,4 @@
-from traitlets import HasTraits, Unicode, Instance
-
-from remoteappmanager.db import orm
+from traitlets import HasTraits, Unicode, Any
 
 
 class User(HasTraits):
@@ -10,5 +8,7 @@ class User(HasTraits):
     # The username as passed at the config line
     name = Unicode()
 
+    # FIXME: orm_user is Any to support other database implementation
+
     #: Can be none if the username cannot be found in the database.
-    orm_user = Instance(orm.User, allow_none=True)
+    orm_user = Any()

--- a/tests/db/abc_test_interfaces.py
+++ b/tests/db/abc_test_interfaces.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod, ABCMeta
-from collections import Iterable
 import inspect as _inspect
 
 from remoteappmanager.db.interfaces import ABCApplication, ABCApplicationPolicy

--- a/tests/db/abc_test_interfaces.py
+++ b/tests/db/abc_test_interfaces.py
@@ -20,33 +20,15 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
             if getattr(policy1, arg) != getattr(policy2, arg):
                 raise self.failureException(msg)
 
-    def setUp(self, users, application_configs):
-        """ Given a list of users, associate a list of
-        tuple(Application, ApplicationPolicy) for each user.
+    @abstractmethod
+    def create_expected_users(self):
+        """ Return a list of expected users """
 
-        Examples
-        --------
-        setUp((User('user1'), User('user2'),
-              ( # user1
-                (
-                   (Application(...), ApplicationPolicy(...)),
-                   (Application(...), ApplicationPolicy(...))
-                )
-                # user2
-                (
-                   (Application(...), ApplicationPolicy(...)),
-                )
-              ))
+    @abstractmethod
+    def create_expected_configs(self, user):
+        """ Return a list of (Application, ApplicationPolicy) pair for
+        the given user.
         """
-        if not (users and application_configs):
-            raise ValueError("usernames and application_configs must not "
-                             "be empty")
-
-        for configs in application_configs:
-            if not isinstance(configs, Iterable):
-                raise TypeError("{!0} is not iterable.".format(configs))
-
-        self.user_config_mappings = dict(zip(users, application_configs))
 
     @abstractmethod
     def create_accounting(self):
@@ -61,7 +43,9 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
         """
         accounting = self.create_accounting()
 
-        for user, expected_configs in self.user_config_mappings.items():
+        for user in self.create_expected_users():
+            expected_configs = self.create_expected_configs(user)
+
             # should be ((mapping_id, Application, ApplicationPolicy),
             #            (mapping_id, Application, ApplicationPolicy) ... )
             actual_id_configs = accounting.get_apps_for_user(user)
@@ -73,7 +57,9 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
 
             # Compare the content of list of (Application, ApplicationPolicy)
             # Note that their order does not matter
-            self.assertEqual(len(actual_configs), len(expected_configs))
+            self.assertEqual(len(actual_configs), len(expected_configs),
+                             "Expected: {}, Actual: {}".format(
+                                 expected_configs, actual_configs))
 
             temp = list(actual_configs)
             for expected in expected_configs:

--- a/tests/db/test_interfaces.py
+++ b/tests/db/test_interfaces.py
@@ -35,20 +35,17 @@ class Accounting(ABCAccounting):
 
 class TestDatabaseInterface(ABCTestDatabaseInterface, unittest.TestCase):
     def setUp(self):
-        super().setUp([User('foo'), User('bar')],
-                      [(
-                          (Application(image='foo1'), ApplicationPolicy()),
-                          (Application(image='foo2'), ApplicationPolicy())
-                      ),
-                       (
-                           (Application(image='bar1'), ApplicationPolicy()),
-                           (Application(image='bar2'), ApplicationPolicy())
-                       )])
-
         self.addTypeEqualityFunc(Application,
                                  self.assertApplicationEqual)
         self.addTypeEqualityFunc(ApplicationPolicy,
                                  self.assertApplicationPolicyEqual)
+
+    def create_expected_users(self):
+        return [User('foo'), User('bar')]
+
+    def create_expected_configs(self, user):
+        return [(Application(image=user.name+'1'), ApplicationPolicy()),
+                (Application(image=user.name+'2'), ApplicationPolicy())]
 
     def create_accounting(self):
         return Accounting()

--- a/tests/db/test_orm.py
+++ b/tests/db/test_orm.py
@@ -3,7 +3,7 @@ import unittest
 
 from remoteappmanager.db import orm
 from remoteappmanager.db.orm import (Database, transaction, Accounting,
-                                     AccountingInterface)
+                                     AppAccounting)
 from tests.db.abc_test_interfaces import ABCTestDatabaseInterface
 from tests.temp_mixin import TempMixin
 from tests import utils
@@ -157,7 +157,7 @@ class TestOrm(TempMixin, unittest.TestCase):
                                               policy))
 
 
-class TestOrmInterface(TempMixin, ABCTestDatabaseInterface, unittest.TestCase):
+class TestOrmAppAccounting(TempMixin, ABCTestDatabaseInterface, unittest.TestCase):
     def setUp(self):
         # Setup temporary directory
         super().setUp()
@@ -189,7 +189,7 @@ class TestOrmInterface(TempMixin, ABCTestDatabaseInterface, unittest.TestCase):
         return mappings[user.name]
 
     def create_accounting(self):
-        accounting = AccountingInterface(
+        accounting = AppAccounting(
             url="sqlite:///"+self.sqlite_file_path)
 
         # Fill the database

--- a/tests/db/test_orm.py
+++ b/tests/db/test_orm.py
@@ -2,7 +2,9 @@ import os
 import unittest
 
 from remoteappmanager.db import orm
-from remoteappmanager.db.orm import Database, transaction, Accounting
+from remoteappmanager.db.orm import (Database, transaction, Accounting,
+                                     AccountingInterface)
+from tests.db.abc_test_interfaces import ABCTestDatabaseInterface
 from tests.temp_mixin import TempMixin
 from tests import utils
 
@@ -153,3 +155,51 @@ class TestOrm(TempMixin, unittest.TestCase):
                                               None,
                                               applications[0],
                                               policy))
+
+
+class TestOrmInterface(TempMixin, ABCTestDatabaseInterface, unittest.TestCase):
+    def setUp(self):
+        # Setup temporary directory
+        super().setUp()
+
+        # Setup the database
+        self.sqlite_file_path = os.path.join(self.tempdir, "sqlite.db")
+        utils.init_sqlite_db(self.sqlite_file_path)
+
+        self.addTypeEqualityFunc(orm.Application, self.assertApplicationEqual)
+        self.addTypeEqualityFunc(orm.ApplicationPolicy,
+                                 self.assertApplicationPolicyEqual)
+
+    def create_expected_users(self):
+        return tuple(orm.User(name='user'+str(i)) for i in range(5))
+
+    def create_expected_configs(self, user):
+        apps = [orm.Application(image="docker/image"+str(i))
+                for i in range(3)]
+        policy = orm.ApplicationPolicy(allow_home=False,
+                                       allow_common=False,
+                                       allow_view=False)
+        mappings = {
+            'user0': ((apps[1], policy),),
+            'user1': ((apps[0], policy),
+                      (apps[2], policy)),
+            'user2': (()),
+            'user3': ((apps[0], policy),),
+            'user4': ((apps[0], policy),)}
+        return mappings[user.name]
+
+    def create_accounting(self):
+        accounting = AccountingInterface(
+            url="sqlite:///"+self.sqlite_file_path)
+
+        # Fill the database
+        fill_db(accounting.session)
+
+        return accounting
+
+    def test_get_user_by_name(self):
+        accounting = self.create_accounting()
+
+        user = accounting.get_user_by_name('user1')
+        self.assertIsInstance(user, orm.User)
+        self.assertEqual(user.name, 'user1')

--- a/tests/db/test_orm.py
+++ b/tests/db/test_orm.py
@@ -203,3 +203,7 @@ class TestOrmInterface(TempMixin, ABCTestDatabaseInterface, unittest.TestCase):
         user = accounting.get_user_by_name('user1')
         self.assertIsInstance(user, orm.User)
         self.assertEqual(user.name, 'user1')
+
+        # user not found, result should be None
+        user = accounting.get_user_by_name('foo')
+        self.assertIsNone(user)

--- a/tests/db/test_orm.py
+++ b/tests/db/test_orm.py
@@ -157,7 +157,8 @@ class TestOrm(TempMixin, unittest.TestCase):
                                               policy))
 
 
-class TestOrmAppAccounting(TempMixin, ABCTestDatabaseInterface, unittest.TestCase):
+class TestOrmAppAccounting(TempMixin, ABCTestDatabaseInterface,
+                           unittest.TestCase):
     def setUp(self):
         # Setup temporary directory
         super().setUp()


### PR DESCRIPTION
Depends on #47 

the `remoteappmanager.db` is now an instance of `orm.AccountingInterface` which subclass `ABCAccounting`

- [x] Add test for `orm.AccountingInterface`

Note: AccountingInterface <--- I am not sold on this name :(