### PR TITLE
verify_token always return a dict and not raise an HTTPError

### DIFF
--- a/remoteappmanager/handlers/base_handler.py
+++ b/remoteappmanager/handlers/base_handler.py
@@ -3,7 +3,6 @@ from urllib.parse import urljoin
 from tornado import web
 
 from remoteappmanager.logging.logging_mixin import LoggingMixin
-from tornado.httpclient import HTTPError
 
 
 class BaseHandler(web.RequestHandler, LoggingMixin):
@@ -14,13 +13,9 @@ class BaseHandler(web.RequestHandler, LoggingMixin):
         cookie_name = self.settings["cookie_name"]
         user_cookie = self.get_cookie(cookie_name)
         if user_cookie:
-            try:
-                verified = hub.verify_token(cookie_name, user_cookie)
-                if verified:
-                    return self.application.user
-            except HTTPError:
-                return None
-
+            user_data = hub.verify_token(cookie_name, user_cookie)
+            if user_data.get('name', '') == self.application.user.name:
+                return self.application.user
         return None
 
     def render(self, template_name, **kwargs):

--- a/remoteappmanager/services/hub.py
+++ b/remoteappmanager/services/hub.py
@@ -44,7 +44,6 @@ class Hub(LoggingMixin, HasTraits):
         r = requests.get(request_url,
                          headers={'Authorization': 'token %s' % self.api_key})
 
-        self.log.info(str(r.__dict__))
         if r.status_code < 400:
             return r.json()
         else:

--- a/remoteappmanager/services/hub.py
+++ b/remoteappmanager/services/hub.py
@@ -31,7 +31,7 @@ class Hub(LoggingMixin, HasTraits):
         -------
         user_data : dict
             If authentication is successful, user_data contains the user's
-            information from jupyterhub associated with the given encryted
+            information from jupyterhub associated with the given encrypted
             cookie.  Otherwise the dictionary is empty.
         """
 

--- a/remoteappmanager/services/hub.py
+++ b/remoteappmanager/services/hub.py
@@ -44,6 +44,7 @@ class Hub(LoggingMixin, HasTraits):
         r = requests.get(request_url,
                          headers={'Authorization': 'token %s' % self.api_key})
 
+        self.log.info(str(r.__dict__))
         if r.status_code < 400:
             return r.json()
         else:

--- a/remoteappmanager/services/hub.py
+++ b/remoteappmanager/services/hub.py
@@ -1,7 +1,6 @@
 import requests
 from urllib.parse import quote
 
-from tornado.httpclient import HTTPError
 from traitlets import HasTraits, Unicode
 
 from remoteappmanager.logging.logging_mixin import LoggingMixin
@@ -30,7 +29,10 @@ class Hub(LoggingMixin, HasTraits):
 
         Returns
         -------
-        True if cookie is verified as valid. Otherwise, raise an HTTPError
+        user_data : dict
+            If authentication is successful, user_data contains the user's
+            information from jupyterhub associated with the given encryted
+            cookie.  Otherwise the dictionary is empty.
         """
 
         # URL for the authorization requiest
@@ -42,15 +44,7 @@ class Hub(LoggingMixin, HasTraits):
         r = requests.get(request_url,
                          headers={'Authorization': 'token %s' % self.api_key})
 
-        if r.status_code == 403:
-            self.log.error("Auth token may have expired: [%i] %s",
-                           r.status_code, r.reason)
-            raise HTTPError(500,
-                            "Permission failure checking authorization, "
-                            "please restart.")
-        elif r.status_code >= 400:
-            self.log.warn("Failed to check authorization: [%i] %s",
-                          r.status_code, r.reason)
-            raise HTTPError(500, "Failed to check authorization")
-
-        return True
+        if r.status_code < 400:
+            return r.json()
+        else:
+            return {}

--- a/tests/handlers/test_home_handler.py
+++ b/tests/handlers/test_home_handler.py
@@ -109,13 +109,14 @@ class TestHomeHandler(TempMixin, AsyncHTTPTestCase):
         self.assertIn("Available Applications", str(res.body))
 
     def test_failed_auth(self):
-        self._app.hub.verify_token.side_effect = HTTPError(500, "Unworthy")
+        self._app.hub.verify_token.return_value = {}
         res = self.fetch("/user/username/",
                          headers={
                              "Cookie": "jupyter-hub-token-username=foo"
                          }
                          )
 
+        self.assertGreaterEqual(res.code, 400)
         self.assertIn(self._app.file_config.login_url, res.effective_url)
         self.assertNotIn("Available Applications", str(res.body))
 


### PR DESCRIPTION
`verify_token` would return a dict containing the user data from jupyterhub and the remoteappmanager would further verify the data.  The dictionary is empty if authentication/authorisation fails.

HTTPError is not raised, but in the future we may want to introduce the HTTPError back again for better error message on the user's end.