### PR TITLE
Add support for validating docker image name in remoteappdb

### DIFF
--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -62,6 +62,11 @@ def get_docker_client():
     return client
 
 
+class RemoteAppDBContext(object):
+    def __init__(self, db):
+        self.db = database(db)
+
+
 @click.group()
 @click.option("--db",
               type=click.STRING,
@@ -71,15 +76,14 @@ def get_docker_client():
 @click.pass_context
 def cli(ctx, db):
     """Main click group placeholder."""
-    ctx.obj["db"] = database(db)
+    ctx.obj = RemoteAppDBContext(db)
 
 
 @cli.command()
 @click.pass_context
 def init(ctx):
     """Initializes the database."""
-    db = ctx.obj["db"]
-    db.reset()
+    ctx.obj.db.reset()
 
 # -------------------------------------------------------------------------
 # User commands
@@ -96,7 +100,7 @@ def user():
 @click.pass_context
 def create(ctx, user):
     """Creates a user USER in the database."""
-    db = ctx.obj["db"]
+    db = ctx.obj.db
     session = db.create_session()
     orm_user = orm.User(name=user)
 
@@ -115,7 +119,7 @@ def create(ctx, user):
 @click.pass_context
 def remove(ctx, user):
     """Removes a user."""
-    db = ctx.obj["db"]
+    db = ctx.obj.db
     session = db.create_session()
 
     try:
@@ -153,7 +157,7 @@ def list(ctx, no_decoration, show_apps):
             headers += ["App", "Home", "View", "Common", "Vol. Source",
                         "Vol. Target", "Vol. Mode"]
 
-    db = ctx.obj["db"]
+    db = ctx.obj.db
     session = db.create_session()
 
     table = []
@@ -209,7 +213,7 @@ def create(ctx, image, verify):
             raise click.BadParameter(msg.format(error=str(exception)),
                                      ctx=ctx)
 
-    db = ctx.obj["db"]
+    db = ctx.obj.db
     session = db.create_session()
     try:
         with orm.transaction(session):
@@ -226,7 +230,7 @@ def create(ctx, image, verify):
 @click.pass_context
 def remove(ctx, image):
     """Removes an application from the list."""
-    db = ctx.obj["db"]
+    db = ctx.obj.db
     session = db.create_session()
 
     try:
@@ -247,7 +251,7 @@ def remove(ctx, image):
 @click.pass_context
 def list(ctx, no_decoration):
     """List all registered applications."""
-    db = ctx.obj["db"]
+    db = ctx.obj.db
 
     if no_decoration:
         tablefmt = "plain"
@@ -281,7 +285,7 @@ def list(ctx, no_decoration):
 def grant(ctx, image, user, allow_home, allow_view, volume):
     """Grants access to application identified by IMAGE to a specific
     user USER and specified access policy."""
-    db = ctx.obj["db"]
+    db = ctx.obj.db
     allow_common = False
     source = target = mode = None
 
@@ -361,7 +365,7 @@ def grant(ctx, image, user, allow_home, allow_view, volume):
 def revoke(ctx, image, user, revoke_all, allow_home, allow_view, volume):
     """Revokes access to application identified by IMAGE to a specific
     user USER and specified parameters."""
-    db = ctx.obj["db"]
+    db = ctx.obj.db
 
     allow_common = False
     source = target = mode = None

--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -53,9 +53,11 @@ def get_docker_client():
     client = docker.from_env()
     try:
         client.info()
-    except ConnectionError:
-        print_error('docker client fails to connect. '
-                    'Is your docker running? Try Docker Toolbox.')
+    except ConnectionError as exception:
+        # ConnectionError occurs, say, if the docker machine is not running
+        # or if the shell is not in a docker VM (for Mac/Windows)
+        print_error('docker client fails to connect. Exception: {}'.format(
+            str(exception)))
         raise
 
     return client

--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -56,8 +56,7 @@ def get_docker_client():
     except ConnectionError as exception:
         # ConnectionError occurs, say, if the docker machine is not running
         # or if the shell is not in a docker VM (for Mac/Windows)
-        print_error('docker client fails to connect. Exception: {}'.format(
-            str(exception)))
+        print_error('docker client fails to connect.')
         raise
 
     return client

--- a/tests/cli/test_remoteappdb.py
+++ b/tests/cli/test_remoteappdb.py
@@ -6,6 +6,7 @@ from unittest import mock
 from click.testing import CliRunner
 
 from remoteappmanager.cli.remoteappdb import __main__ as remoteappdb
+from remoteappmanager.cli.remoteappdb.__main__ import RemoteAppDBContext
 from tests.temp_mixin import TempMixin
 from tests.utils import mock_docker_client
 
@@ -15,7 +16,7 @@ def _context_factory(*args, **kwargs):
     with the given arguments and keyword arguments
     """
     def main_context(*args, **kwargs):
-        return remoteappdb.RemoteAppDBContext(*args, **kwargs)
+        return RemoteAppDBContext(*args, **kwargs)
     return main_context
 
 

--- a/tests/cli/test_remoteappdb.py
+++ b/tests/cli/test_remoteappdb.py
@@ -6,7 +6,6 @@ from unittest import mock
 from click.testing import CliRunner
 
 from remoteappmanager.cli.remoteappdb import __main__ as remoteappdb
-from remoteappmanager.cli.remoteappdb.__main__ import RemoteAppDBContext
 from tests.temp_mixin import TempMixin
 from tests.utils import mock_docker_client
 
@@ -16,7 +15,7 @@ def _context_factory(*args, **kwargs):
     with the given arguments and keyword arguments
     """
     def main_context(*args, **kwargs):
-        return RemoteAppDBContext(*args, **kwargs)
+        return remoteappdb.RemoteAppDBContext(*args, **kwargs)
     return main_context
 
 
@@ -67,7 +66,7 @@ class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):
             # Initialise database
             runner.invoke(remoteappdb.cli, ['init'])
 
-            # docker.client.inspect_image is mocked to always
+            # docker.client.inspect_image is mocked to always return
             # something, so verification would pass
             result = runner.invoke(remoteappdb.cli,
                                    ['app', 'create', 'anything'])

--- a/tests/cli/test_remoteappdb.py
+++ b/tests/cli/test_remoteappdb.py
@@ -1,8 +1,33 @@
 import os
 import unittest
 import subprocess
+from unittest import mock
 
+from click.testing import CliRunner
+
+from remoteappmanager.cli.remoteappdb import __main__ as remoteappdb
+from remoteappmanager.cli.remoteappdb.__main__ import RemoteAppDBContext
 from tests.temp_mixin import TempMixin
+from tests.utils import mock_docker_client
+
+
+def _context_factory(*args, **kwargs):
+    """ Return a factory for creating RemoteAppDBContext
+    with the given arguments and keyword arguments
+    """
+    def main_context(*args, **kwargs):
+        return RemoteAppDBContext(*args, **kwargs)
+    return main_context
+
+
+def mock_context(*args, **kwargs):
+    """ Mock the RemoteAppDBContext in the click script
+    with the given arguments and keyword arguments
+    """
+    context_factory = _context_factory(*args, **kwargs)
+    return mock.patch(
+        'remoteappmanager.cli.remoteappdb.__main__.RemoteAppDBContext',
+        context_factory)
 
 
 class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):
@@ -33,15 +58,66 @@ class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):
         self.assertIn("foo", out)
         self.assertIn("bar", out)
 
-    def test_app_create(self):
-        out = self._remoteappdb("app create myapp")
-        self.assertEqual(out, "1\n")
+    def test_app_create_with_verify(self):
+        runner = CliRunner()
 
-        out = self._remoteappdb("app list")
-        self.assertIn("myapp", out)
+        with mock_context(db=self.db), \
+                 mock.patch('remoteappmanager.cli.remoteappdb.__main__.get_docker_client',  # noqa
+                            mock_docker_client):
+            # Initialise database
+            runner.invoke(remoteappdb.cli, ['init'])
+
+            # docker.client.inspect_image is mocked to always
+            # something, so verification would pass
+            result = runner.invoke(remoteappdb.cli,
+                                   ['app', 'create', 'anything'])
+
+            self.assertEqual(result.exit_code, 0)
+
+            # Check that the app is created
+            result = runner.invoke(remoteappdb.cli,
+                                   ['app', 'list'])
+            self.assertIn('anything', result.output)
+
+    def test_app_create_wrong_name_with_verify(self):
+        runner = CliRunner()
+
+        with mock_context(db=self.db):
+            # Initialise database
+            runner.invoke(remoteappdb.cli, ['init'])
+
+            # create an application with a wrong image name
+            result = runner.invoke(remoteappdb.cli,
+                                   ['app', 'create', 'anything'])
+
+            self.assertEqual(result.exit_code, 2)
+
+            # Check that the app is not created
+            result = runner.invoke(remoteappdb.cli,
+                                   ['app', 'list'])
+            self.assertNotIn('anything', result.output)
+
+    def test_app_create_wrong_name_without_verify(self):
+        runner = CliRunner()
+
+        with mock_context(db=self.db):
+            # Initialise database
+            runner.invoke(remoteappdb.cli, ['init'])
+
+            # create an application with a wrong image name
+            result = runner.invoke(remoteappdb.cli,
+                                   ['app', 'create', 'anything',
+                                    '--no-verify'])
+
+            self.assertEqual(result.exit_code, 0)
+
+            # Check that the app is not created
+            result = runner.invoke(remoteappdb.cli,
+                                   ['app', 'list'])
+            self.assertIn('anything', result.output)
 
     def test_app_grant(self):
-        self._remoteappdb("app create myapp")
+        self._remoteappdb("app create myapp --no-verify")
         self._remoteappdb("user create user")
 
         out = self._remoteappdb("user list")
@@ -57,7 +133,7 @@ class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):
         self.assertIn(" ro\n", out)
 
     def test_app_revoke(self):
-        self._remoteappdb("app create myapp")
+        self._remoteappdb("app create myapp --no-verify")
         self._remoteappdb("user create user")
 
         self._remoteappdb("app grant myapp user")

--- a/tests/cli/test_remoteappdb.py
+++ b/tests/cli/test_remoteappdb.py
@@ -80,7 +80,7 @@ class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-        # Check that the app is not created
+        # Check that the app is created
         result = runner.invoke(remoteappdb.cli,
                                ['--db='+self.db, 'app', 'list'])
         self.assertIn('wrong2', result.output)


### PR DESCRIPTION
Provides for #58 

Also introduced `click.testing.CliRunner` in the tests and `RemoteAppDBContext` in remoteappdb.__main__ so that we can mock and test the module (docker in this case) without relying on subprocess.
Opening an issue for applying the same strategy for other tests outside the scope of #58.
