### PR TITLE
Ensure mapping id from CSVAccounting contains only hex characters

### DIFF
--- a/remoteappmanager/db/csv_db.py
+++ b/remoteappmanager/db/csv_db.py
@@ -44,6 +44,7 @@ Note
 """
 
 import csv
+import hashlib
 
 from remoteappmanager.db.interfaces import (
     ABCAccounting, ABCApplication, ABCApplicationPolicy)
@@ -132,9 +133,11 @@ class CSVAccounting(ABCAccounting):
 
                 # Save the configuration
                 # Note that we don't filter existing duplicate entry
+                mapping_id_prehex = '_'.join((application.image, str(count)))
                 self.all_records.setdefault(username, []).append(
-                    ('_'.join((application.image, str(count))),
-                     application, application_policy))
+                    (hashlib.md5(mapping_id_prehex.encode('u8')).hexdigest(),
+                     application,
+                     application_policy))
 
     def get_user_by_name(self, user_name):
         """ Return a CSVUser for a given user_name, or return

--- a/tests/db/abc_test_interfaces.py
+++ b/tests/db/abc_test_interfaces.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod, ABCMeta
 import inspect as _inspect
+import string
 
 from remoteappmanager.db.interfaces import ABCApplication, ABCApplicationPolicy
 
@@ -80,7 +81,7 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
 
     def test_get_apps_for_user_mapping_id_rest_compliant(self):
         ''' Test if the mapping_id to be rest identifier complient '''
-        allowed_chars = set('0123456789abcdef')
+        allowed_chars = set(string.ascii_letters+string.digits)
         accounting = self.create_accounting()
 
         for user in self.create_expected_users():

--- a/tests/db/abc_test_interfaces.py
+++ b/tests/db/abc_test_interfaces.py
@@ -77,3 +77,24 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
 
             if temp:
                 self.fail('These are not expected: {}'.format(temp))
+
+    def test_get_apps_for_user_mapping_id_rest_compliant(self):
+        ''' Test if the mapping_id to be rest identifier complient '''
+        allowed_chars = set('0123456789abcdef')
+        accounting = self.create_accounting()
+
+        for user in self.create_expected_users():
+            # should be ((mapping_id, Application, ApplicationPolicy),
+            #            (mapping_id, Application, ApplicationPolicy) ... )
+            actual_id_configs = accounting.get_apps_for_user(user)
+
+            if not actual_id_configs:
+                continue
+
+            mapping_ids, _, _ = zip(*actual_id_configs)
+
+            self.assertFalse(
+                any(set(mapping_id) - allowed_chars
+                    for mapping_id in mapping_ids),
+                "mapping id should contain these characters only: {} "
+                "Got : {}".format(allowed_chars, mapping_ids))

--- a/tests/db/abc_test_interfaces.py
+++ b/tests/db/abc_test_interfaces.py
@@ -92,10 +92,8 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
             if not actual_id_configs:
                 continue
 
-            mapping_ids, _, _ = zip(*actual_id_configs)
-
-            self.assertFalse(
-                any(set(mapping_id) - allowed_chars
-                    for mapping_id in mapping_ids),
-                "mapping id should contain these characters only: {} "
-                "Got : {}".format(allowed_chars, mapping_ids))
+            for mapping_id, _, _ in actual_id_configs:
+                self.assertFalse(
+                    set(mapping_id) - allowed_chars,
+                    "mapping id should contain these characters only: {} "
+                    "Got : {}".format(allowed_chars, mapping_id))

--- a/tests/db/test_interfaces.py
+++ b/tests/db/test_interfaces.py
@@ -27,9 +27,9 @@ class Accounting(ABCAccounting):
         return User(name=username)
 
     def get_apps_for_user(self, user):
-        return (('mapping_id1',
+        return (('abc1',
                  Application(image=user.name+'1'), ApplicationPolicy()),
-                ('mapping_id2',
+                ('abc2',
                  Application(image=user.name+'2'), ApplicationPolicy()))
 
 


### PR DESCRIPTION
Follows #80, mapping id containing '/' would cause problem with the rest api.
Added tests.
