### PR TITLE
Ensure config_file_path is configurable for Spawner

### DIFF
--- a/remoteappmanager/spawner.py
+++ b/remoteappmanager/spawner.py
@@ -20,7 +20,7 @@ class Spawner(LocalProcessSpawner):
     proxy = Any()
 
     #: The path of the configuration file for the cmd executable
-    config_file_path = Unicode()
+    config_file_path = Unicode(config=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Fix #91 
This should be tested in jupyterhub, so we shouldn't need to test it (as we have not done).