### PR TITLE
Extracting authenticator code to service REST handlers

### DIFF
--- a/remoteappmanager/handlers/base_handler.py
+++ b/remoteappmanager/handlers/base_handler.py
@@ -4,10 +4,14 @@ from urllib.parse import urljoin
 from tornado import web, gen
 
 from remoteappmanager.logging.logging_mixin import LoggingMixin
+from remoteappmanager.handlers.handler_authenticator import HubAuthenticator
 
 
 class BaseHandler(web.RequestHandler, LoggingMixin):
     """Base class for the request handler."""
+
+    #: The authenticator that is used to recognize the user.
+    authenticator_class = HubAuthenticator
 
     @gen.coroutine
     def prepare(self):
@@ -15,17 +19,8 @@ class BaseHandler(web.RequestHandler, LoggingMixin):
 
         # Authenticate the user against the hub. We can't use get_current_user
         # because we want to do it asynchronously.
-        hub = self.application.hub
-        cookie_name = self.settings["cookie_name"]
-        user_cookie = self.get_cookie(cookie_name)
-        user = None
-
-        if user_cookie:
-            user_data = (yield hub.verify_token(cookie_name, user_cookie))
-            if user_data.get('name', '') == self.application.user.name:
-                user = self.application.user
-
-        self.current_user = user
+        authenticator = self.authenticator_class()
+        self.current_user = yield authenticator.authenticate(self)
 
     def render(self, template_name, **kwargs):
         """Reimplements render to pass well known information to the rendering

--- a/remoteappmanager/handlers/handler_authenticator.py
+++ b/remoteappmanager/handlers/handler_authenticator.py
@@ -1,0 +1,32 @@
+from tornado import gen
+
+
+class Authenticator:
+    """Base authenticator class for the web handlers"""
+    @gen.coroutine
+    def authenticate(self, handler):
+        """Called by the handler to authenticate the user.
+        The handler passes itself as an argument, and expects a valid
+        handler.current_user value, or None"""
+        return None
+
+
+class HubAuthenticator(Authenticator):
+    """Authenticator that uses the remote JupyterHub to validate
+    the request."""
+    @gen.coroutine
+    def authenticate(self, handler):
+        # Authenticate the user against the hub. We can't use get_current_user
+        # because we want to do it asynchronously.
+        webapp = handler.application
+        hub = webapp.hub
+        cookie_name = handler.settings["cookie_name"]
+        user_cookie = handler.get_cookie(cookie_name)
+        user = None
+
+        if user_cookie:
+            user_data = (yield hub.verify_token(cookie_name, user_cookie))
+            if user_data.get('name', '') == webapp.user.name:
+                user = webapp.user
+
+        return user

--- a/remoteappmanager/handlers/tests/test_handler_authenticator.py
+++ b/remoteappmanager/handlers/tests/test_handler_authenticator.py
@@ -1,0 +1,14 @@
+from unittest import mock
+from tornado.testing import AsyncTestCase, gen_test
+
+from remoteappmanager.handlers.handler_authenticator import Authenticator
+
+
+class TestHandlerAuthenticator(AsyncTestCase):
+    @gen_test
+    def test_base_authenticator(self):
+        auth = Authenticator()
+        result = yield auth.authenticate(mock.Mock())
+        self.assertIsNone(result)
+
+    # HubAuthenticator covered by higher level tests.


### PR DESCRIPTION
Extracted authenticator so that we can inject it in the REST handlers coming from tornado-rest, at the moment still not supporting this feature.
