### PR TITLE
Fixes xForward dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ deps:
 	-sudo apt-get update
 	sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine npm nodejs-legacy python3-pip python3.4-venv
 	pip3 install --upgrade pip setuptools
-	sudo npm install -g git://github.com/stefanoborini/configurable-http-proxy.git#fix-x-forward
+	# Currently set to 1.4.0dev fixing X-Forward behavior
+	sudo npm install -g "git://github.com/jupyterhub/configurable-http-proxy.git#f54c6a46a235f17cb6c36046a913d37fa45ec95b"
 	pip3 install -r requirements.txt 
 
 .PHONY: devdeps

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ deps:
 	-sudo apt-get update
 	sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine npm nodejs-legacy python3-pip python3.4-venv
 	pip3 install --upgrade pip setuptools
-	sudo npm install -g configurable-http-proxy
+	sudo npm install -g git://github.com/stefanoborini/configurable-http-proxy.git#fix-x-forward
 	pip3 install -r requirements.txt 
 
 .PHONY: devdeps


### PR DESCRIPTION
Current release of configurable-http-proxy has a bug that inverts the logic
of x-forward addition. This ruins the functionality of anything reverseproxied,
specifically the file transfer (which relies on these headers to produce the correct
urls)