### PR TITLE
Fix requests version to 2.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 setuptools>=21.0
 traitlets>=4.1
 tornado>=4.3
-# Fix to 2.2.0 due to docker-py needs (fails with 2.2.1)
-requests==2.2.0
+# Fix to 2.10.0 due to docker-py needs (fails with 2.11.1)
+requests==2.10.0
 docker-py>=1.8
 escapism>=0.0.1
 jinja2>=2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 setuptools>=21.0
 traitlets>=4.1
 tornado>=4.3
+# Fix to 2.2.0 due to docker-py needs (fails with 2.2.1)
+requests==2.2.0
 docker-py>=1.8
 escapism>=0.0.1
 jinja2>=2.8

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "traitlets>=4.1",
         "tornado>=4.3",
         "docker-py>=1.8",
+        "requests>=2.10.0",
         "escapism>=0.0.1",
         "jinja2>=2.8",
         "jupyterhub>=0.7.0dev0",


### PR DESCRIPTION
Solves a conflict of versions between the current ubuntu deployment and the need for dockerpy. Pegged version for requests to 2.10.0