### PR TITLE
Handle webapi requests failures

### DIFF
--- a/remoteappmanager/static/js/home.js
+++ b/remoteappmanager/static/js/home.js
@@ -73,17 +73,6 @@ require(
             $("#bny_"+index).hide();
         };
 
-        var fill_local_model = function (promises) {
-            // Fills the local application model with the results of the
-            // retrieve promises.
-            for (var i = 0; i < promises.length; i++) {
-                var result = promises[i];
-                if (result[2].status === 200) {
-                    application_model.push(result[0]);
-                }
-            }
-        };
-        
         var render_applist = function () {
             // Renders the full application list and adds it to the DOM.
             var html = "";
@@ -162,8 +151,12 @@ require(
             $(".bny").click(y_button_clicked);
         };
         
+        var sync_local_model = function (app_data) {
+            application_model = app_data;
+        };
+        
         $.when(appapi.available_applications_info())
-            .done(fill_local_model)
+            .done(sync_local_model)
             .done(render_applist)
             .done(register_button_eventhandlers);
         ;

--- a/remoteappmanager/static/js/home.js
+++ b/remoteappmanager/static/js/home.js
@@ -162,22 +162,11 @@ require(
             $(".bny").click(y_button_clicked);
         };
         
-        var request_app_infos = function (response) {
-            // Retrieve information from the various applications and 
-            // connect the cascading callbacks.
-            var requests = [];
-
-            for (var i = 0; i < response.items.length; i++) {
-                requests.push(appapi.application_info(response.items[i]));
-            }
-
-            utils.all(requests)
-                .always(fill_local_model)
-                .done(render_applist)
-                .done(register_button_eventhandlers);
-        };
-
-        $.when(appapi.available_applications()).done(request_app_infos);
+        $.when(appapi.available_applications_info())
+            .done(fill_local_model)
+            .done(render_applist)
+            .done(register_button_eventhandlers);
+        ;
 
     }
 );

--- a/remoteappmanager/static/js/home.js
+++ b/remoteappmanager/static/js/home.js
@@ -159,7 +159,6 @@ require(
             .done(sync_local_model)
             .done(render_applist)
             .done(register_button_eventhandlers);
-        ;
 
     }
 );

--- a/remoteappmanager/static/js/remoteappapi.js
+++ b/remoteappmanager/static/js/remoteappapi.js
@@ -93,33 +93,39 @@ define(['jquery', 'utils'], function ($, utils) {
         var self = this;
 
         $.when(self.available_applications(options))
-            .done(
-                function (response) {
-                    var request, requests = [];
+            .done(function (response) {
+                var request, requests = [];
 
-                    for (var i = 0; i < response.items.length; i++) {
-                        // We neutralize the potential error from a jXHR request
-                        // and make sure that all our requests "succeed" so that
-                        // all/when can guarantee everything is done.
-                        request = $.Deferred();
+                for (var i = 0; i < response.items.length; i++) {
+                    // We neutralize the potential error from a jXHR request
+                    // and make sure that all our requests "succeed" so that
+                    // all/when can guarantee everything is done.
+                    request = $.Deferred();
 
-                        // These will go out of scope but they are still alive
-                        // and performing to completion
-                        self.application_info(response.items[i]).always(
-                            request.resolve);
+                    // These will go out of scope but they are still alive
+                    // and performing to completion
+                    self.application_info(response.items[i]).always(
+                        request.resolve);
 
-                        requests.push(request);
-                    }
-
-                    utils.all(requests).done(
-                        function (promises) {
-                            promise.resolve(promises);
-                        }
-                    );
-                
+                    requests.push(request);
                 }
-            );
-        
+
+                utils.all(requests)
+                    .done(function (promises) {
+                        // Fills the local application model with the results of the
+                        // retrieve promises.
+                            var data = [];
+                            for (var i = 0; i < promises.length; i++) {
+                                var result = promises[i];
+                                if (result[2].status === 200) {
+                                    data.push(result[0]);
+                                }
+                            }
+                            promise.resolve(data);
+                    });
+            
+            });
+                
         return promise;
     };
 

--- a/remoteappmanager/static/js/remoteappapi.js
+++ b/remoteappmanager/static/js/remoteappapi.js
@@ -2,6 +2,8 @@ define(['jquery', 'utils'], function ($, utils) {
     "use strict";
 
     var RemoteAppAPI = function (base_url) {
+        // Object representing the interface to the Web API.
+        // @param base_url : the url at which to find the web API endpoint.
         this.base_url = base_url;
     };
     
@@ -15,70 +17,129 @@ define(['jquery', 'utils'], function ($, utils) {
         error: null
     };
    
-    var update = function (d1, d2) {
-        $.map(d2, function (i, key) {
-            d1[key] = d2[key];
-        });
-        return d1;
-    };
-    
     var ajax_defaults = function (options) {
         var d = {};
-        update(d, default_options);
-        update(d, options);
+        utils.update(d, default_options);
+        utils.update(d, options);
         return d;
     };
     
-    RemoteAppAPI.prototype.api_request = function (path, options) {
-        options = options || {};
-        options = ajax_defaults(options || {});
-        var url = utils.url_path_join(
-            this.base_url,
-            'api',
-            'v1',
-            utils.encode_uri_components(path)
-        )+'/';
-        
-        return $.ajax(url, options);
-    };
-    
     RemoteAppAPI.prototype.start_application = function(id, options) {
+        // Starts an application with a given id. (async)
+        //
+        // @param id : the mapping id of the application to start.
+        // @param options : the options for the request. Optional.
+        // @return a deferred object for the request.
         options = options || {};
-        options = update(options, {
+        options = utils.update(options, {
             type: 'POST', 
             data: JSON.stringify({
                 mapping_id: id
             })});
-        return this.api_request(
+        return this._api_request(
             'containers',
             options
         );
     };
 
     RemoteAppAPI.prototype.stop_application = function (id, options) {
+        // Stops an application with a given container id. (async)
+        //
+        // @param id : the container id of the started application.
+        //             Note that this is different from the mapping id.
+        // @param options : the options for the request. Optional. 
+        // @return a deferred object for the request.
         options = options || {};
-        options = update(options, {type: 'DELETE'});
-        return this.api_request(
+        options = utils.update(options, {type: 'DELETE'});
+        return this._api_request(
             utils.url_path_join('containers', id),
             options
         );
     };
 
     RemoteAppAPI.prototype.available_applications = function (options) {
+        // Requests the available applications. (async)
+        //
+        // @param options : the options for the request. Optional. 
+        // @return a deferred object for the request.
         options = options || {};
-        return this.api_request(
+        return this._api_request(
             utils.url_path_join('applications'),
             options
         );
     };
     
     RemoteAppAPI.prototype.application_info = function (id, options) {
+        // Requests a given application information via its mapping id 
+        // (name, icon, etc). (async)
+        //
+        // @param id : the mapping id of the application to start.
+        // @param options : the options for the request. Optional. 
+        // @return a deferred object for the request.
         options = options || {};
-        return this.api_request(
+        return this._api_request(
             utils.url_path_join('applications', id),
             options
         );
     };
-    
+
+    RemoteAppAPI.prototype.available_applications_info = function (options) {
+        // Retrieve information from the various applications and
+        // connect the cascading callbacks.
+        // Returns a single promise. When resolved, the attached 
+        // callbacks will be passed an array of the promises for the various
+        // retrieve operations, successful or not.
+        var promise = $.Deferred();
+        var self = this;
+
+        $.when(self.available_applications(options))
+            .done(
+                function (response) {
+                    var request, requests = [];
+
+                    for (var i = 0; i < response.items.length; i++) {
+                        // We neutralize the potential error from a jXHR request
+                        // and make sure that all our requests "succeed" so that
+                        // all/when can guarantee everything is done.
+                        request = $.Deferred();
+
+                        // These will go out of scope but they are still alive
+                        // and performing to completion
+                        self.application_info(response.items[i]).always(
+                            request.resolve);
+
+                        requests.push(request);
+                    }
+
+                    utils.all(requests).done(
+                        function (promises) {
+                            promise.resolve(promises);
+                        }
+                    );
+                
+                }
+            );
+        
+        return promise;
+    };
+
+    // Private
+    RemoteAppAPI.prototype._api_request = function (path, options) {
+        // Performs a request to the final endpoint
+        // @param path : the relative path of the endpoint
+        // @param options : the options for the request. Optional. 
+        // @return a deferred object for the request.
+        options = options || {};
+        options = ajax_defaults(options || {});
+        var url = utils.url_path_join(
+                this.base_url,
+                'api',
+                'v1',
+                utils.encode_uri_components(path)
+            )+'/';
+
+        return $.ajax(url, options);
+    };
+
     return RemoteAppAPI;
 });

--- a/remoteappmanager/static/js/utils.js
+++ b/remoteappmanager/static/js/utils.js
@@ -141,6 +141,14 @@ define(['jquery'], function ($) {
         });
     };
     
+    var update = function (d1, d2) {
+        // Transfers the keys from d2 to d1. Returns d1
+        $.map(d2, function (i, key) {
+            d1[key] = d2[key];
+        });
+        return d1;
+    };
+
     var utils = {
         url_path_join : url_path_join,
         url_join_encode : url_join_encode,
@@ -149,11 +157,12 @@ define(['jquery'], function ($) {
         get_body_data : get_body_data,
         parse_url : parse_url,
         browser : browser,
-        platform: platform,
+        platform : platform,
         ajax_error_msg : ajax_error_msg,
         log_ajax_error : log_ajax_error,
         ajax_error_dialog : ajax_error_dialog,
-        all : all
+        all : all,
+        update : update
     };
     
     return utils;


### PR DESCRIPTION
Skips the entries that err, for whatever reason, at the JS client level.

Fixes #221