### PR TITLE
Remove sudo in npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ jupyterhub_cookie_secret
 doc/build
 doc/source/api
 doc/source/remoteappmanager_help.txt
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps:
 	sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine npm nodejs-legacy python3-pip python3.4-venv
 	pip3 install --upgrade pip setuptools
 	# Currently set to 1.4.0dev fixing X-Forward behavior
-	sudo npm install -g "git://github.com/jupyterhub/configurable-http-proxy.git#f54c6a46a235f17cb6c36046a913d37fa45ec95b"
+	npm install "git://github.com/jupyterhub/configurable-http-proxy.git#f54c6a46a235f17cb6c36046a913d37fa45ec95b"
 	pip3 install -r requirements.txt 
 
 .PHONY: devdeps

--- a/jupyterhub/start.sh
+++ b/jupyterhub/start.sh
@@ -1,1 +1,8 @@
+if [ "${0:0:1}" = '/' ]; then
+    SCRIPT_DIR=`dirname "$0"`
+else
+    cwd=`pwd`
+    SCRIPT_DIR=`dirname "$cwd/$0"`
+fi
+export PATH=$SCRIPT_DIR/../node_modules/.bin/:$PATH
 jupyterhub --ssl-key test.key --ssl-cert test.crt


### PR DESCRIPTION
Fixes #237.
Removes sudo in npm install so that we don't use the -g (global) option.