### PR TITLE
Doc and makefile for Ubuntu14.04 updated docker engine.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@ venv:
 	@echo "----------------------------"
 	python3 -m venv venv
 
+# Only use this on ubuntu-14.04 to retrieve a recent version of docker-engine. The docker.io default shipment with Trusty is
+# too old for our software.
+.PHONY: dockerengine
+dockerengine:
+	sudo apt-get update
+	sudo apt-get install apt-transport-https ca-certificates
+	sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+	sudo bash -c 'echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list'
+	sudo apt-get update
+
 .PHONY: deps
 deps:
 	@echo "Installing apt dependencies"

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -15,6 +15,13 @@ Deployment of the complete system in a single machine/VM.
 
      git clone https://github.com/simphony/simphony-remote
 
+#. Make sure that you are obtaining a recent version of Docker, at least 1.12.
+   Full instructions available at `the Docker website <https://docs.docker.com/engine/installation/linux/ubuntulinux/>`_.
+   A Makefile rule is provided for convenience. **NOTE: this overwrites the docker.list file you might have setup in your
+   /etc/apt/sources.d/ directory**.  You might be prompted for the root password to execute this::
+     
+     make dockerengine
+
 #. Install dependencies. You might be prompted for the root password to execute this::
 
      make deps


### PR DESCRIPTION
Provides documentation and a makefile rule to retrieve an up-to-date version of docker-engine from the docker apt sources.
