### PR TITLE
Export image type

### DIFF
--- a/remoteappmanager/docker/docker_labels.py
+++ b/remoteappmanager/docker/docker_labels.py
@@ -38,4 +38,8 @@ SIMPHONY_NS = DockerLabelNamespace(
         # practice this is hard to obtain from inside the container,
         # leading to a chicken/egg situation
         "url_id",
+        # The type of the image: at the moment, it can be either
+        # "vncapp", "webapp" or not present (for legacy apps). This will
+        # affect the configurability of the image at startup.
+        "type",
     ])

--- a/remoteappmanager/docker/image.py
+++ b/remoteappmanager/docker/image.py
@@ -9,7 +9,7 @@ class Image(HasTraits):
     #: The docker id of the image
     docker_id = Unicode()
 
-    #: The name of the
+    #: The name of the image.
     name = Unicode()
 
     #: The user interface (web) name of the image.
@@ -20,6 +20,10 @@ class Image(HasTraits):
 
     #: A long description of the image.
     description = Unicode()
+
+    #: The type of the image. This allows to differentiate image behavior
+    #: once started.
+    type = Unicode()
 
     @classmethod
     def from_docker_dict(cls, docker_dict):

--- a/remoteappmanager/docker/image.py
+++ b/remoteappmanager/docker/image.py
@@ -51,5 +51,6 @@ class Image(HasTraits):
             self.ui_name = labels.get(SIMPHONY_NS.ui_name, '')
             self.icon_128 = labels.get(SIMPHONY_NS.icon_128, '')
             self.description = labels.get(SIMPHONY_NS.description, '')
+            self.type = labels.get(SIMPHONY_NS.type, '')
 
         return self

--- a/remoteappmanager/docker/tests/test_image.py
+++ b/remoteappmanager/docker/tests/test_image.py
@@ -18,6 +18,7 @@ class TestImage(TestCase):
                          image_dict["Labels"][SIMPHONY_NS.description])
         self.assertEqual(image.ui_name,
                          image_dict["Labels"][SIMPHONY_NS.ui_name])
+        self.assertEqual(image.type, 'vncapp')
 
     def test_from_docker_dict_inspect_image(self):
         docker_client = create_docker_client()
@@ -32,3 +33,11 @@ class TestImage(TestCase):
         self.assertEqual(
             image.ui_name,
             image_dict['Config']["Labels"][SIMPHONY_NS.ui_name])
+        self.assertEqual(image.type, 'vncapp')
+
+    def test_missing_image_type(self):
+        docker_client = create_docker_client()
+        image_dict = docker_client.inspect_image('image_id2')
+        image = Image.from_docker_dict(image_dict)
+
+        self.assertEqual(image.type, '')

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -34,7 +34,9 @@ def get_fake_image_labels(num=2):
     samples = cycle(
         (
             {'eu.simphony-project.docker.description': 'Ubuntu machine with mayavi preinstalled',  # noqa
-             'eu.simphony-project.docker.ui_name': 'Mayavi 4.4.4'},
+             'eu.simphony-project.docker.ui_name': 'Mayavi 4.4.4',
+             'eu.simphony-project.docker.type': 'vncapp',
+             },
             {'eu.simphony-project.docker.description': 'A vanilla Ubuntu installation'},  # noqa
         )
     )


### PR DESCRIPTION
We need to differentiate image types (vnc, web) to decide which parameters to pass when creating them.