### PR TITLE
Made configurables optional. Introduced default.

### DIFF
--- a/remoteappmanager/docker/configurables.py
+++ b/remoteappmanager/docker/configurables.py
@@ -52,6 +52,15 @@ class Configurable(metaclass=abc.ABCMeta):
             image at startup.
         """
 
+    @classmethod
+    def default_env(cls):
+        """Provides a default environment in case the config_dict does not
+        contain anything. Return a fully valid env dict or None for no
+        default. If None is returned, the appropriate course of action
+        is to consider the config dict invalid and raise a ValueError
+        """
+        return None
+
 
 class Resolution(Configurable):
     """Support for images that allow resolution change of the VNC server."""
@@ -74,6 +83,9 @@ class Resolution(Configurable):
         Observe that the key used has nothing to do with the tag.
         They are only accidentally the same.
         """
+        if config_dict is None or len(config_dict) == 0:
+            return cls.default_env()
+
         resolution = config_dict["resolution"]
         w, h = [int(value) for value in resolution.split("x")]
         if w <= 0 or h <= 0:
@@ -82,6 +94,14 @@ class Resolution(Configurable):
         return {
             "X11_WIDTH": str(w),
             "X11_HEIGHT": str(h),
+            "X11_DEPTH": "16"
+        }
+
+    @classmethod
+    def default_env(cls):
+        return {
+            "X11_WIDTH": "1024",
+            "X11_HEIGHT": "768",
             "X11_DEPTH": "16"
         }
 

--- a/remoteappmanager/docker/tests/test_configurables.py
+++ b/remoteappmanager/docker/tests/test_configurables.py
@@ -24,15 +24,22 @@ class TestConfigurables(unittest.TestCase):
 
     def test_config_dict_to_env(self):
         self.assertEqual(
-            Resolution.config_dict_to_env({"resolution": "1024x768"}),
-            {"X11_WIDTH": "1024",
-             "X11_HEIGHT": "768",
+            Resolution.config_dict_to_env({"resolution": "1280x800"}),
+            {"X11_WIDTH": "1280",
+             "X11_HEIGHT": "800",
              "X11_DEPTH": "16"
              }
         )
 
-        with self.assertRaises(KeyError):
-            Resolution.config_dict_to_env({})
+        default = Resolution.default_env()
+        self.assertEqual(default,
+                         {"X11_WIDTH": "1024",
+                          "X11_HEIGHT": "768",
+                          "X11_DEPTH": "16"
+                          }
+                         )
+        self.assertEqual(Resolution.config_dict_to_env(None), default)
+        self.assertEqual(Resolution.config_dict_to_env({}), default)
 
         with self.assertRaises(ValueError):
             Resolution.config_dict_to_env({"resolution": "1024"})

--- a/remoteappmanager/restresources/container.py
+++ b/remoteappmanager/restresources/container.py
@@ -280,7 +280,8 @@ class Container(Resource):
         env = {}
 
         for img_conf in image.configurables:
-            config_dict = representation["configurables"][img_conf.tag]
+            config_dict = representation.get(
+                "configurables", {}).get(img_conf.tag, {})
             env.update(img_conf.config_dict_to_env(config_dict))
 
         return env


### PR DESCRIPTION
To support the command line client, we want configurable options to be optional.
If nothing is specified, the server will try to use a default, and if no default is present, it should act as in a bad representation.