### PR TITLE
Hiding deployed/personalized files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,10 @@ jupyterhub_cookie_secret
 doc/build
 doc/source/api
 doc/source/remoteappmanager_help.txt
+remoteappmanager/static/components/
 node_modules
+.coverage
+build/
+dist/
+jupyterhub/remoteappmanager.db
+jupyterhub/test.key.org


### PR DESCRIPTION
Hiding the new bower components directory, plus a few other files that are not relevant or generated.
Fixes part of #271 