### PR TITLE
Assign absolute urlpath to the container.

### DIFF
--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -41,7 +41,8 @@ class Container(HasTraits):
     user = Unicode()
 
     #: The url path of the container as it is exported to the user.
-    frontend_urlpath = Unicode()
+    #: e.g. "/home/test/containers/12345/"
+    urlpath = Unicode()
 
     @property
     def host_url(self):
@@ -142,7 +143,6 @@ class Container(HasTraits):
         kwargs["mapping_id"] = labels.get(SIMPHONY_NS_RUNINFO.mapping_id) or ""
         kwargs["url_id"] = labels.get(SIMPHONY_NS_RUNINFO.url_id) or ""
         kwargs["user"] = labels.get(SIMPHONY_NS_RUNINFO.user) or ""
-        kwargs["frontend_urlpath"] = labels.get(
-            SIMPHONY_NS_RUNINFO.frontend_urlpath) or ""
+        kwargs["urlpath"] = labels.get(SIMPHONY_NS_RUNINFO.urlpath) or ""
 
         return cls(**kwargs)

--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -29,16 +29,19 @@ class Container(HasTraits):
     #: ...and port where the container service will be listening
     port = Int(80)
 
-    #: the id that will go in the URL of the container
+    #: The id that will go in the URL of the container.
+    #: This is a de-facto replacement for the container docker id. The reason
+    #: why we don't use that instead is because the container id is difficult
+    #: to obtain reliably from inside the container, and because we want more
+    #: flexibility in the form of the user-exposed id.
+    #: Important: must be globally unique, not just per-user unique.
     url_id = Unicode()
 
     #: The user currently running the container
     user = Unicode()
 
-    @property
-    def urlpath(self):
-        """Returns the relative url of the Container."""
-        return "containers/{}".format(self.url_id)
+    #: The url path of the container as it is exported to the user.
+    frontend_urlpath = Unicode()
 
     @property
     def host_url(self):
@@ -139,5 +142,7 @@ class Container(HasTraits):
         kwargs["mapping_id"] = labels.get(SIMPHONY_NS_RUNINFO.mapping_id) or ""
         kwargs["url_id"] = labels.get(SIMPHONY_NS_RUNINFO.url_id) or ""
         kwargs["user"] = labels.get(SIMPHONY_NS_RUNINFO.user) or ""
+        kwargs["frontend_urlpath"] = labels.get(
+            SIMPHONY_NS_RUNINFO.frontend_urlpath) or ""
 
         return cls(**kwargs)

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -11,7 +11,9 @@ from remoteappmanager.docker.docker_labels import SIMPHONY_NS_RUNINFO
 
 from remoteappmanager.docker.image import Image
 from remoteappmanager.logging.logging_mixin import LoggingMixin
-from remoteappmanager.utils import url_path_join
+from remoteappmanager.utils import (
+    url_path_join,
+    without_end_slash)
 
 from tornado import gen
 from traitlets import (
@@ -320,8 +322,10 @@ class ContainerManager(LoggingMixin):
             '\n'.join('{0} -> {1}'.format(source, target['bind'])
                       for source, target in filtered_volumes.items()))
 
-        container_urlpath = url_path_join(
-            base_urlpath, "containers", container_url_id)
+        container_urlpath = without_end_slash(
+            url_path_join(base_urlpath,
+                          "containers",
+                          container_url_id))
 
         create_kwargs = dict(
             image=image_name,
@@ -566,7 +570,7 @@ def _get_container_env(user_name, url_id, environment, base_urlpath):
         JPY_USER=user_name,
         # The base url. We use this one because the JPY username might
         # have been escaped.
-        JPY_BASE_USER_URL=base_urlpath,
+        JPY_BASE_USER_URL=without_end_slash(base_urlpath),
         # A unix username. used in the container to create the user.
         USER=_unix_user(user_name),
         # The identifier that will be used for the URL.

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -69,8 +69,8 @@ class ContainerManager(LoggingMixin):
                         user_name,
                         image_name,
                         mapping_id,
-                        volumes,
                         base_urlpath,
+                        volumes,
                         environment=None):
         """
         Starts a container using the given image name.
@@ -87,10 +87,10 @@ class ContainerManager(LoggingMixin):
             it is expected to be unique (and persistent) for a specific
             combination of docker image (i.e. application) and setup
             (i.e. configuration).
-        volumes: dict or None
-            {volume_source: {'bind': volume_target, 'mode': volume_mode}
         base_urlpath: str
             The base urlpath for the current user.
+        volumes: dict or None
+            {volume_source: {'bind': volume_target, 'mode': volume_mode}
         environment: dict or None
             Contains additional keyvalue pairs that will be exported
             as environment variables inside the container.
@@ -117,8 +117,8 @@ class ContainerManager(LoggingMixin):
             result = yield self._start_container(user_name,
                                                  image_name,
                                                  mapping_id,
-                                                 volumes,
                                                  base_urlpath,
+                                                 volumes,
                                                  environment)
         finally:
             self._start_pending.remove(mapping_id)
@@ -253,8 +253,8 @@ class ContainerManager(LoggingMixin):
                          user_name,
                          image_name,
                          mapping_id,
-                         volumes,
                          base_urlpath,
+                         volumes,
                          environment):
         """Helper method that performs the physical operation of starting
         the container.
@@ -328,7 +328,8 @@ class ContainerManager(LoggingMixin):
             name=container_name,
             environment=_get_container_env(user_name,
                                            container_url_id,
-                                           environment),
+                                           environment,
+                                           base_urlpath),
             volumes=volume_targets,
             labels=_get_container_labels(user_name,
                                          mapping_id,

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -320,7 +320,7 @@ class ContainerManager(LoggingMixin):
             '\n'.join('{0} -> {1}'.format(source, target['bind'])
                       for source, target in filtered_volumes.items()))
 
-        container_frontend_urlpath = url_path_join(
+        container_urlpath = url_path_join(
             base_urlpath, "containers", container_url_id)
 
         create_kwargs = dict(
@@ -334,7 +334,7 @@ class ContainerManager(LoggingMixin):
             labels=_get_container_labels(user_name,
                                          mapping_id,
                                          container_url_id,
-                                         container_frontend_urlpath))
+                                         container_urlpath))
 
         # build the dictionary of keyword arguments for host_config
         host_config = dict(
@@ -387,7 +387,7 @@ class ContainerManager(LoggingMixin):
             ip=ip,
             port=port,
             url_id=container_url_id,
-            frontend_urlpath=container_frontend_urlpath,
+            urlpath=container_urlpath,
         )
 
         self.log.info(
@@ -575,7 +575,7 @@ def _get_container_env(user_name, url_id, environment, base_urlpath):
     return result
 
 
-def _get_container_labels(user_name, mapping_id, url_id, frontend_urlpath):
+def _get_container_labels(user_name, mapping_id, url_id, urlpath):
     """Returns a dictionary that will become container run-time labels.
     Each of these labels must be namespaced in reverse DNS style, in agreement
     to docker guidelines."""
@@ -584,7 +584,7 @@ def _get_container_labels(user_name, mapping_id, url_id, frontend_urlpath):
         SIMPHONY_NS_RUNINFO.user: user_name,
         SIMPHONY_NS_RUNINFO.mapping_id: mapping_id,
         SIMPHONY_NS_RUNINFO.url_id: url_id,
-        SIMPHONY_NS_RUNINFO.frontend_urlpath: frontend_urlpath,
+        SIMPHONY_NS_RUNINFO.urlpath: urlpath,
     }
 
 

--- a/remoteappmanager/docker/docker_labels.py
+++ b/remoteappmanager/docker/docker_labels.py
@@ -62,5 +62,11 @@ SIMPHONY_NS_RUNINFO = DockerLabelNamespace(
         # practice this is hard to obtain from inside the container,
         # leading to a chicken/egg situation
         "url_id",
+        # The URL path where the container is exposed.
+        # For example, if the user accesses it at
+        # https://host:8000/user/username/containers/12345/
+        # it will be /user/username/containers/12345/.
+        # This is also the url that's been added to the reverse proxy.
+        "frontend_urlpath"
     ],
 )

--- a/remoteappmanager/docker/docker_labels.py
+++ b/remoteappmanager/docker/docker_labels.py
@@ -67,6 +67,6 @@ SIMPHONY_NS_RUNINFO = DockerLabelNamespace(
         # https://host:8000/user/username/containers/12345/
         # it will be /user/username/containers/12345/.
         # This is also the url that's been added to the reverse proxy.
-        "frontend_urlpath"
+        "urlpath"
     ],
 )

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -9,13 +9,6 @@ from remoteappmanager.tests.mocking.virtual.docker_client import (
 
 
 class TestContainer(TestCase):
-    def test_url(self):
-        container = Container(
-            url_id="12345"
-        )
-
-        self.assertEqual(container.urlpath, "containers/12345")
-
     def test_host_url(self):
         container = Container(
             ip="123.45.67.89",
@@ -79,7 +72,9 @@ class TestContainer(TestCase):
             ip='0.0.0.0',
             port=80,
             url_id="url_id",
-            mapping_id="mapping_id")
+            mapping_id="mapping_id",
+            urlpath="/user/username/containers/url_id/"
+        )
 
         assert_containers_equal(self, actual, expected)
 
@@ -97,7 +92,9 @@ class TestContainer(TestCase):
             ip='0.0.0.0',
             port=666,
             url_id="url_id",
-            mapping_id="mapping_id")
+            mapping_id="mapping_id",
+            urlpath="/user/username/containers/url_id/"
+        )
 
         assert_containers_equal(self, actual, expected)
 

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -67,7 +67,7 @@ class TestContainerManager(AsyncTestCase):
                              ip='127.0.0.1',
                              port=666,
                              url_id='url_id',
-                             urlpath="/user/username/containers/url_id/")
+                             urlpath="/user/username/containers/url_id")
 
         self.assertEqual(len(result), 1)
         utils.assert_containers_equal(self, result[0], expected)
@@ -85,7 +85,7 @@ class TestContainerManager(AsyncTestCase):
                              ip='127.0.0.1',
                              port=666,
                              url_id='url_id',
-                             urlpath="/user/username/containers/url_id/",
+                             urlpath="/user/username/containers/url_id",
                              )
 
         utils.assert_containers_equal(self, result, expected)

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -31,7 +31,7 @@ class TestContainerManager(AsyncTestCase):
             "username",
             'image_id1',
             "new_mapping_id",
-            "/base/url/",
+            "/base/url",
             None,
             None)
         self.assertTrue(mock_client.start.called)
@@ -161,7 +161,7 @@ class TestContainerManager(AsyncTestCase):
             "username",
             "image_name1",
             "mapping_id",
-            "/base/url/",
+            "/base/url",
             None,
             None)
         self.assertTrue(mock_client.start.called)
@@ -200,7 +200,7 @@ class TestContainerManager(AsyncTestCase):
         yield self.manager.start_container("username",
                                            "image_id1",
                                            "mapping_id",
-                                           "/foo/bar/",
+                                           "/foo/bar",
                                            volumes,
                                            )
 
@@ -230,7 +230,7 @@ class TestContainerManager(AsyncTestCase):
             yield self.manager.start_container("username",
                                                "image_id1",
                                                "mapping_id",
-                                               "/base/url/",
+                                               "/base/url",
                                                None,
                                                None)
 
@@ -252,7 +252,7 @@ class TestContainerManager(AsyncTestCase):
             yield self.manager.start_container("username",
                                                "image_id1",
                                                "mapping_id",
-                                               "/base/url/",
+                                               "/base/url",
                                                None,
                                                None)
 
@@ -271,7 +271,7 @@ class TestContainerManager(AsyncTestCase):
             "username",
             "image_name1",
             "mapping_id",
-            "/base/url/",
+            "/base/url",
             None,
             environment)
 

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -31,6 +31,8 @@ class TestContainerManager(AsyncTestCase):
             "username",
             'image_id1',
             "new_mapping_id",
+            None,
+            "/base/url/",
             None)
         self.assertTrue(mock_client.start.called)
         self.assertTrue(mock_client.create_container.called)
@@ -115,12 +117,14 @@ class TestContainerManager(AsyncTestCase):
         f1 = self.manager.start_container("username",
                                           "image_id1",
                                           "mapping_id",
-                                          None)
+                                          None,
+                                          "/foo/bar")
 
         f2 = self.manager.start_container("username",
                                           "image_id1",
                                           "mapping_id",
-                                          None)
+                                          None,
+                                          "/foo/baz")
 
         # If these yielding raise a KeyError, it is because the second
         # one tries to remove the same key from the list, but it has been
@@ -152,6 +156,8 @@ class TestContainerManager(AsyncTestCase):
             "username",
             "image_name1",
             "mapping_id",
+            None,
+            "/base/url/",
             None)
         self.assertTrue(mock_client.start.called)
         self.assertIsInstance(result, Container)
@@ -189,7 +195,8 @@ class TestContainerManager(AsyncTestCase):
         yield self.manager.start_container("username",
                                            "image_id1",
                                            "mapping_id",
-                                           volumes)
+                                           volumes,
+                                           "/foo/bar")
 
         # Call args and keyword args that create_container receives
         docker_client = self.manager.docker_client
@@ -217,6 +224,8 @@ class TestContainerManager(AsyncTestCase):
             yield self.manager.start_container("username",
                                                "image_id1",
                                                "mapping_id",
+                                               None,
+                                               "/base/url/",
                                                None)
 
         self.assertTrue(self.mock_docker_client.stop.called)
@@ -237,6 +246,8 @@ class TestContainerManager(AsyncTestCase):
             yield self.manager.start_container("username",
                                                "image_id1",
                                                "mapping_id",
+                                               None,
+                                               "/base/url/",
                                                None)
 
         self.assertTrue(self.mock_docker_client.stop.called)
@@ -255,8 +266,8 @@ class TestContainerManager(AsyncTestCase):
             "image_name1",
             "mapping_id",
             None,
-            environment
-            )
+            "/base/url/",
+            environment)
 
         self.assertEqual(
             mock_client.create_container.call_args[1]["environment"]["FOO"],

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -31,8 +31,8 @@ class TestContainerManager(AsyncTestCase):
             "username",
             'image_id1',
             "new_mapping_id",
-            None,
             "/base/url/",
+            None,
             None)
         self.assertTrue(mock_client.start.called)
         self.assertTrue(mock_client.create_container.called)
@@ -66,7 +66,8 @@ class TestContainerManager(AsyncTestCase):
                              image_id='image_id1',
                              ip='127.0.0.1',
                              port=666,
-                             url_id='url_id')
+                             url_id='url_id',
+                             urlpath="/user/username/containers/url_id/")
 
         self.assertEqual(len(result), 1)
         utils.assert_containers_equal(self, result[0], expected)
@@ -83,7 +84,9 @@ class TestContainerManager(AsyncTestCase):
                              image_id='image_id1',
                              ip='127.0.0.1',
                              port=666,
-                             url_id='url_id')
+                             url_id='url_id',
+                             urlpath="/user/username/containers/url_id/",
+                             )
 
         utils.assert_containers_equal(self, result, expected)
 
@@ -117,14 +120,16 @@ class TestContainerManager(AsyncTestCase):
         f1 = self.manager.start_container("username",
                                           "image_id1",
                                           "mapping_id",
+                                          "/foo/bar",
                                           None,
-                                          "/foo/bar")
+                                          )
 
         f2 = self.manager.start_container("username",
                                           "image_id1",
                                           "mapping_id",
+                                          "/foo/baz",
                                           None,
-                                          "/foo/baz")
+                                          )
 
         # If these yielding raise a KeyError, it is because the second
         # one tries to remove the same key from the list, but it has been
@@ -156,8 +161,8 @@ class TestContainerManager(AsyncTestCase):
             "username",
             "image_name1",
             "mapping_id",
-            None,
             "/base/url/",
+            None,
             None)
         self.assertTrue(mock_client.start.called)
         self.assertIsInstance(result, Container)
@@ -195,8 +200,9 @@ class TestContainerManager(AsyncTestCase):
         yield self.manager.start_container("username",
                                            "image_id1",
                                            "mapping_id",
+                                           "/foo/bar/",
                                            volumes,
-                                           "/foo/bar")
+                                           )
 
         # Call args and keyword args that create_container receives
         docker_client = self.manager.docker_client
@@ -224,8 +230,8 @@ class TestContainerManager(AsyncTestCase):
             yield self.manager.start_container("username",
                                                "image_id1",
                                                "mapping_id",
-                                               None,
                                                "/base/url/",
+                                               None,
                                                None)
 
         self.assertTrue(self.mock_docker_client.stop.called)
@@ -246,8 +252,8 @@ class TestContainerManager(AsyncTestCase):
             yield self.manager.start_container("username",
                                                "image_id1",
                                                "mapping_id",
-                                               None,
                                                "/base/url/",
+                                               None,
                                                None)
 
         self.assertTrue(self.mock_docker_client.stop.called)
@@ -265,8 +271,8 @@ class TestContainerManager(AsyncTestCase):
             "username",
             "image_name1",
             "mapping_id",
-            None,
             "/base/url/",
+            None,
             environment)
 
         self.assertEqual(

--- a/remoteappmanager/restresources/container.py
+++ b/remoteappmanager/restresources/container.py
@@ -7,7 +7,6 @@ from tornadowebapi import exceptions
 from tornadowebapi.exceptions import NotFound
 from tornadowebapi.resource import Resource
 
-from remoteappmanager.utils import url_path_join
 from remoteappmanager.netutils import wait_for_http_server_2xx
 from remoteappmanager.restresources.decorators import authenticated
 
@@ -303,8 +302,7 @@ class Container(Resource):
         server_url = "http://{}:{}{}/".format(
             container.ip,
             container.port,
-            url_path_join(self.application.command_line_config.base_urlpath,
-                          container.urlpath))
+            container.urlpath)
 
         yield wait_for_http_server_2xx(
             server_url,

--- a/remoteappmanager/restresources/container.py
+++ b/remoteappmanager/restresources/container.py
@@ -60,7 +60,8 @@ class Container(Resource):
                 app,
                 policy,
                 mapping_id,
-                environment
+                self.application.command_line_config.base_urlpath,
+                environment=environment
                 )
         except Exception as e:
             raise exceptions.Unable(message=str(e))
@@ -71,13 +72,10 @@ class Container(Resource):
             self._remove_container_noexcept(container)
             raise exceptions.Unable(message=str(e))
 
-        urlpath = url_path_join(
-            self.application.command_line_config.base_urlpath,
-            container.urlpath)
-
         try:
             yield self.application.reverse_proxy.register(
-                urlpath, container.host_url)
+                container.frontend_urlpath,
+                container.host_url)
         except Exception as e:
             self._remove_container_noexcept(container)
             raise exceptions.Unable(message=str(e))
@@ -119,12 +117,10 @@ class Container(Resource):
         if container.user != self.current_user.name:
             raise exceptions.NotFound()
 
-        urlpath = url_path_join(
-            self.application.command_line_config.base_urlpath,
-            container.urlpath)
-
         try:
-            yield self.application.reverse_proxy.unregister(urlpath)
+            yield self.application.reverse_proxy.unregister(
+                container.frontend_urlpath
+            )
         except Exception:
             # If we can't remove the reverse proxy, we cannot do much more
             # than log the problem and keep going, because we want to stop

--- a/remoteappmanager/restresources/container.py
+++ b/remoteappmanager/restresources/container.py
@@ -74,7 +74,7 @@ class Container(Resource):
 
         try:
             yield self.application.reverse_proxy.register(
-                container.frontend_urlpath,
+                container.urlpath,
                 container.host_url)
         except Exception as e:
             self._remove_container_noexcept(container)
@@ -119,7 +119,7 @@ class Container(Resource):
 
         try:
             yield self.application.reverse_proxy.unregister(
-                container.frontend_urlpath
+                container.urlpath
             )
         except Exception:
             # If we can't remove the reverse proxy, we cannot do much more
@@ -193,6 +193,7 @@ class Container(Resource):
                          app,
                          policy,
                          mapping_id,
+                         base_urlpath,
                          environment):
         """Start the container. This method is a helper method that
         works with low level data and helps in issuing the request to the
@@ -244,6 +245,7 @@ class Container(Resource):
             f = manager.start_container(user_name,
                                         image_name,
                                         mapping_id,
+                                        base_urlpath,
                                         volumes,
                                         environment
                                         )

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -76,7 +76,8 @@ def get_fake_container_states(num=3):
 def get_fake_container_labels(num=3):
     samples = cycle(({SIMPHONY_NS_RUNINFO.user: 'user_name',
                       SIMPHONY_NS_RUNINFO.mapping_id: 'mapping_id',
-                      SIMPHONY_NS_RUNINFO.url_id: 'url_id'},
+                      SIMPHONY_NS_RUNINFO.url_id: 'url_id',
+                      SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/url_id/'},  # noqa
                      {SIMPHONY_NS_RUNINFO.user: 'user_name'},
                      {}))
     return tuple(next(samples) for _ in range(num))

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -77,7 +77,7 @@ def get_fake_container_labels(num=3):
     samples = cycle(({SIMPHONY_NS_RUNINFO.user: 'user_name',
                       SIMPHONY_NS_RUNINFO.mapping_id: 'mapping_id',
                       SIMPHONY_NS_RUNINFO.url_id: 'url_id',
-                      SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/url_id/'},  # noqa
+                      SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/url_id'},  # noqa
                      {SIMPHONY_NS_RUNINFO.user: 'user_name'},
                      {}))
     return tuple(next(samples) for _ in range(num))

--- a/remoteappmanager/utils.py
+++ b/remoteappmanager/utils.py
@@ -28,6 +28,11 @@ def with_end_slash(url):
     return url.rstrip("/")+"/"
 
 
+def without_end_slash(url):
+    """Makes sure there is no end slash at the end of a url."""
+    return url.rstrip("/")
+
+
 def parse_volume_string(volume_string):
     """Parses a volume specification string SOURCE:TARGET:MODE into
     its components, or raises click.BadOptionUsage if not according


### PR DESCRIPTION
We need to store the urlpath where the container is, on the container itself. This is the only way we have for an administrative program to know which url to unregister when stopping someone else's container.

Alternative solutions involving changing the configurable http proxy have been debated 

https://github.com/jupyterhub/configurable-http-proxy/pull/87
https://github.com/jupyterhub/configurable-http-proxy/pull/88

and on gitter, and this PR is probably the most sensible strategy.