### PR TITLE
Use mapping id  as a legitimate index to refer to the accounting table

### DIFF
--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -2,6 +2,7 @@
 """Script to perform operations on the database of our application."""
 import os
 import sys
+import uuid
 from requests.exceptions import ConnectionError
 
 import sqlalchemy.exc
@@ -405,7 +406,9 @@ def grant(ctx, image, user, allow_home, allow_view, volume):
         ).one_or_none()
 
         if acc is None:
+            id = uuid.uuid4().hex
             accounting = orm.Accounting(
+                id=id,
                 user=orm_user,
                 application=orm_app,
                 application_policy=orm_policy,

--- a/remoteappmanager/db/csv_db.py
+++ b/remoteappmanager/db/csv_db.py
@@ -44,7 +44,7 @@ Note
 """
 
 import csv
-import hashlib
+import uuid
 
 from remoteappmanager.db.interfaces import (
     ABCAccounting, ABCApplication, ABCApplicationPolicy)
@@ -167,9 +167,8 @@ class CSVAccounting(ABCAccounting):
 
                 # Save the configuration
                 # Note that we don't filter existing duplicate entry
-                mapping_id_prehex = '_'.join((application.image, str(count)))
-                self.all_records.setdefault(user.name, []).append(
-                    (hashlib.md5(mapping_id_prehex.encode('u8')).hexdigest(),
+                self.all_records.setdefault(user.name, []).append((
+                     uuid.uuid4().hex,
                      application,
                      application_policy))
 

--- a/remoteappmanager/db/interfaces.py
+++ b/remoteappmanager/db/interfaces.py
@@ -220,6 +220,11 @@ class ABCAccounting(metaclass=ABCMeta):
             if the app or user are not found.
         ValueError:
             if the volume string is invalid.
+
+        Returns
+        -------
+        id : str
+            A 32 characters id
         """
 
     @abstractmethod

--- a/remoteappmanager/db/tests/test_orm.py
+++ b/remoteappmanager/db/tests/test_orm.py
@@ -1,4 +1,5 @@
 import contextlib
+import uuid
 import os
 import unittest
 
@@ -31,23 +32,24 @@ def fill_db(session):
         # app 1 to be available only to user 0
         # and app 2 to be available to user 1
 
-        accountings = [
-            orm.Accounting(user=users[1],
-                           application=apps[0],
-                           application_policy=policy),
-            orm.Accounting(user=users[3],
-                           application=apps[0],
-                           application_policy=policy),
-            orm.Accounting(user=users[4],
-                           application=apps[0],
-                           application_policy=policy),
-            orm.Accounting(user=users[0],
-                           application=apps[1],
-                           application_policy=policy),
-            orm.Accounting(user=users[1],
-                           application=apps[2],
-                           application_policy=policy),
-        ]
+        accountings = []
+
+        for user, application in [
+                (users[1], apps[0]),
+                (users[3], apps[0]),
+                (users[4], apps[0]),
+                (users[0], apps[1]),
+                (users[1], apps[2])]:
+
+            id = uuid.uuid4().hex
+
+            accountings.append(
+                orm.Accounting(id=id,
+                               user=user,
+                               application=application,
+                               application_policy=policy)
+            )
+
         session.add_all(accountings)
 
 

--- a/remoteappmanager/db/tests/test_orm.py
+++ b/remoteappmanager/db/tests/test_orm.py
@@ -332,17 +332,24 @@ class TestOrmAppAccounting(TempMixin, ABCTestDatabaseInterface,
 
         accounting.create_application("simphonyremote/amazing")
 
-        accounting.grant_access("simphonyremote/amazing", "ciccio",
-                                True, False, "/foo:/bar:ro")
+        id = accounting.grant_access("simphonyremote/amazing", "ciccio",
+                                     True, False, "/foo:/bar:ro")
+        self.assertIsNotNone(id)
 
         user = accounting.get_user(user_name="ciccio")
         apps = accounting.get_apps_for_user(user)
+        self.assertEqual(apps[0][0], id)
         self.assertEqual(apps[0][1].image, "simphonyremote/amazing")
         self.assertEqual(apps[0][2].allow_home, True)
         self.assertEqual(apps[0][2].allow_view, False)
         self.assertEqual(apps[0][2].volume_source, "/foo")
         self.assertEqual(apps[0][2].volume_target, "/bar")
         self.assertEqual(apps[0][2].volume_mode, "ro")
+
+        # Do it twice to check idempotency
+        id2 = accounting.grant_access("simphonyremote/amazing", "ciccio",
+                                      True, False, "/foo:/bar:ro")
+        self.assertEqual(id, id2)
 
         accounting.revoke_access("simphonyremote/amazing", "ciccio",
                                  True, False, "/foo:/bar:ro")


### PR DESCRIPTION
We need to have an id to refer to the accounting table, so that we can perform deletion without
issuing a query, and having an id to refer to via the webapi. The mapping id has done this since the beginning, but it's not in the table. Now it is.

This invalidates the database structure, so the 0.8.0 database will not be compatible.