### PR TITLE
Bumped tornado-webapi to 0.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ git+git://github.com/jupyterhub/jupyterhub.git@42a993fd084780ad23e475f27f67ade3a
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5
-git+git://github.com/simphony/tornado-webapi.git@v0.4.1#egg=tornadowebapi
+git+git://github.com/simphony/tornado-webapi.git@v0.4.2#egg=tornadowebapi

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "jupyter_client>=4.3.0",
     "click>=6.6",
     "tabulate>=0.7.5",
-    "tornadowebapi>=0.4.1"
+    "tornadowebapi>=0.4.2"
 ]
 
 # Unfortunately RTD cannot install jupyterhub because jupyterhub needs bower,


### PR DESCRIPTION
Missing files require that we upgrade, again