### PR TITLE
Fixes incorrect double addition of handler to dialogs when an error occurs

### DIFF
--- a/remoteappmanager/static/js/utils.js
+++ b/remoteappmanager/static/js/utils.js
@@ -126,6 +126,11 @@ define([
 
     var config_dialog = function(dialog_element, title, body, ok_callback, close_callback) {
         var modal = $(dialog_element);
+        
+        // Remove possible already existing handlers
+        modal.find('.modal-footer .primary').off("click");
+        modal.find('.modal-close').off("click");
+        
         if (title !== null) {
             modal.find('.modal-title').text(title);
         }


### PR DESCRIPTION
Fixes a bug that made the request performed twice: jQuery .click() adds, rather than replace, the handler, resulting in multiple handlers being registered to the same event.