### PR TITLE
Fixes forever stuck spinner in case of docker internal failure

### DIFF
--- a/remoteappmanager/static/js/remoteappapi.js
+++ b/remoteappmanager/static/js/remoteappapi.js
@@ -129,6 +129,9 @@ define(['jquery', 'utils'], function ($, utils) {
                         promise.resolve(data);
                     });
             
+            })
+            .fail(function() {
+                promise.resolve([]);
             });
                 
         return promise;


### PR DESCRIPTION
If the docker server is unavaiable for some reason, we want to stop the spinner anyway. We will get plenty of log on the server, but for now the user should not know.