### PR TITLE
Update to jupyterhub master.

### DIFF
--- a/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
@@ -45,6 +45,10 @@ class FileWhitelistMixin(LoggingConfigurable):
 
         return self._whitelist
 
+    @whitelist.setter
+    def whitelist(self, value):
+        print("XXX")
+
 
 class GitHubWhitelistAuthenticator(FileWhitelistMixin, GitHubOAuthenticator):
     """A github authenticator that also verifies that the

--- a/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
@@ -45,10 +45,6 @@ class FileWhitelistMixin(LoggingConfigurable):
 
         return self._whitelist
 
-    @whitelist.setter
-    def whitelist(self, value):
-        print("XXX")
-
 
 class GitHubWhitelistAuthenticator(FileWhitelistMixin, GitHubOAuthenticator):
     """A github authenticator that also verifies that the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 setuptools==21.0
-traitlets==4.1
 tornado==4.3
 # Fix to 2.10.0 due to docker-py needs (fails with 2.11.1)
 requests==2.10.0
@@ -8,7 +7,7 @@ requests==2.10.0
 docker-py==1.8
 escapism==0.0.1
 jinja2==2.8
-git+git://github.com/jupyterhub/jupyterhub.git@0.7.2#egg=jupyterhub
+git+git://github.com/jupyterhub/jupyterhub.git@master#egg=jupyterhub
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ if on_rtd:
     requirements.extend(["sqlalchemy>=1.0"])
 else:
     requirements.extend([
-        "jupyterhub~=0.7",
+        "jupyterhub>0.7",
         "docker-py==1.8",
         "tornadowebapi>=0.4.2"])
 


### PR DESCRIPTION
Forced to update jupyterhub to master to address (again) #354 .
We are now running on jupyterhub development.

It also removes traitlets from the requirements, as it comes in with jupyterhub, and we need that version to be compatible with the rest.
