### PR TITLE
Changes whitelist handling to cope with jupyterhub.

### DIFF
--- a/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
@@ -9,7 +9,7 @@ class FileWhitelistMixin(LoggingConfigurable):
     """
 
     #: The path of the whitelist file.
-    whitelist_file = Unicode()
+    whitelist_file = Unicode(config=True)
 
     #: When the file was last modified, so that we can reload appropriately.
     _whitelist_file_last_modified = Float()
@@ -19,31 +19,43 @@ class FileWhitelistMixin(LoggingConfigurable):
 
     @property
     def whitelist(self):
+        """Returns the whitelist for the approved users.
+        """
+        # Note: we return a copy because other code in jupyterhub
+        # will modify the set. We don't want our cache to be modified.
         try:
             cur_mtime = os.path.getmtime(self.whitelist_file)
             if cur_mtime <= self._whitelist_file_last_modified:
                 # File older than last change.
                 # keep using the current cached whitelist
-                return self._whitelist
+                return set(self._whitelist)
 
             self.log.info("Whitelist file more recent than the old one. "
                           "Updating whitelist.")
 
             with open(self.whitelist_file, "r") as f:
-                whitelisted_users = set(x.strip() for x in f.readlines())
+                whitelisted_users = set(self.normalize_username(x.strip())
+                                        for x in f.readlines())
         except FileNotFoundError:
             # empty set means everybody is allowed
-            return {}
+            return set()
         except Exception:
             # For other exceptions, assume the file is broken, log it
             # and return what we have.
             self.log.exception("Unable to access whitelist.")
-            return self._whitelist
+            return set(self._whitelist)
 
         self._whitelist = whitelisted_users
         self._whitelist_file_last_modified = cur_mtime
 
-        return self._whitelist
+        return set(self._whitelist)
+
+    @whitelist.setter
+    def whitelist(self, value):
+        """Dummy setter that does nothing.
+        Jupyterhub assumes it can normalize the names and set them
+        back. We can't let it perform this operation. """
+        pass
 
 
 class GitHubWhitelistAuthenticator(FileWhitelistMixin, GitHubOAuthenticator):

--- a/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
@@ -86,3 +86,14 @@ class TestGithubWhiteListAuthenticator(TempMixin, AsyncTestCase):
             response = yield auth.get_authenticated_user(Mock(),
                                                          {"username": "foo"})
             self.assertEqual(response, None)
+
+    def test_dummy_setter(self):
+        whitelist_path = os.path.join(self.tempdir, "whitelist.txt")
+        with open(whitelist_path, "w") as f:
+            f.write("bar\n")
+
+        auth = self.auth
+        auth.whitelist_file = whitelist_path
+        auth.whitelist = set()
+        self.assertNotEqual(auth.whitelist, set())
+

--- a/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
@@ -33,7 +33,7 @@ class TestGithubWhiteListAuthenticator(TempMixin, AsyncTestCase):
 
         auth = self.auth
         auth.whitelist_file = whitelist_path
-
+        print (auth.whitelist)
         response = yield auth.get_authenticated_user(Mock(),
                                                      {"username": "foo"})
         self.assertEqual(response, "foo")

--- a/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
@@ -96,4 +96,3 @@ class TestGithubWhiteListAuthenticator(TempMixin, AsyncTestCase):
         auth.whitelist_file = whitelist_path
         auth.whitelist = set()
         self.assertNotEqual(auth.whitelist, set())
-

--- a/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
@@ -33,7 +33,6 @@ class TestGithubWhiteListAuthenticator(TempMixin, AsyncTestCase):
 
         auth = self.auth
         auth.whitelist_file = whitelist_path
-        print (auth.whitelist)
         response = yield auth.get_authenticated_user(Mock(),
                                                      {"username": "foo"})
         self.assertEqual(response, "foo")


### PR DESCRIPTION
Addresses the following issues:

- adds config=True to allow the option to be set at config time.
- returns a copy of the set, because jupyterhub changes it.
- added mock setter to pacify jupyterhub.