### PR TITLE
Made the async docker client instance private

### DIFF
--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -532,7 +532,7 @@ class ContainerManager(LoggingMixin):
         else:
             self.log.info("Container '{}' is removed.".format(container_id))
 
-    @default("docker_client")
+    @default("_docker_client")
     def _docker_client_default(self):
         return AsyncDockerClient(**self.docker_config)
 

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -18,10 +18,10 @@ class TestContainerManager(AsyncTestCase):
         super().setUp()
         self.manager = ContainerManager({})
         self.mock_docker_client = create_docker_client()
-        self.manager.docker_client._sync_client = self.mock_docker_client
+        self.manager._docker_client._sync_client = self.mock_docker_client
 
     def test_instantiation(self):
-        self.assertIsNotNone(self.manager.docker_client)
+        self.assertIsNotNone(self.manager._docker_client)
 
     @gen_test
     def test_start_stop(self):
@@ -102,7 +102,7 @@ class TestContainerManager(AsyncTestCase):
         # Making it so that no valid dictionary is returned.
         docker_client.port = mock.Mock(return_value=1234)
         self.mock_docker_client = docker_client
-        self.manager.docker_client._sync_client = docker_client
+        self.manager._docker_client._sync_client = docker_client
 
         result = yield self.manager.container_from_url_id("url_id")
         self.assertEqual(result, None)
@@ -205,7 +205,7 @@ class TestContainerManager(AsyncTestCase):
                                            )
 
         # Call args and keyword args that create_container receives
-        docker_client = self.manager.docker_client
+        docker_client = self.manager._docker_client
         args = docker_client._sync_client.create_container.call_args
         actual_volume_targets = args[1]['volumes']
 
@@ -224,7 +224,7 @@ class TestContainerManager(AsyncTestCase):
         def raiser(*args, **kwargs):
             raise Exception("Boom!")
 
-        self.manager.docker_client.start = mock.Mock(side_effect=raiser)
+        self.manager._docker_client.start = mock.Mock(side_effect=raiser)
 
         with self.assertRaisesRegex(Exception, 'Boom!'):
             yield self.manager.start_container("username",
@@ -246,7 +246,7 @@ class TestContainerManager(AsyncTestCase):
         def raiser(*args, **kwargs):
             raise Exception("Boom!")
 
-        self.manager.docker_client.port = mock.Mock(side_effect=raiser)
+        self.manager._docker_client.port = mock.Mock(side_effect=raiser)
 
         with self.assertRaisesRegex(Exception, 'Boom!'):
             yield self.manager.start_container("username",

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -224,7 +224,7 @@ def create_container_manager(params=None):
         params = {'docker_config': {}}
 
     manager = ContainerManager(**params)
-    manager.docker_client._sync_client = create_docker_client()
+    manager._docker_client._sync_client = create_docker_client()
     return manager
 
 


### PR DESCRIPTION
There is no reason why the ContainerManager should export the docker client publicly.