### PR TITLE
Use container provenance information to prevent access to unrelated containers or simphony-remote instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ SimPhoNy Remote CHANGELOG
 What's new in SimPhoNy Remote 1.1.0
 -----------------------------------
 
+- Use container provenance information to prevent access to unrelated 
+  containers or simphony-remote instances (#361)
 - Fix: incorrect user name in top header for admin Accounting panel (#348)
 
 What's new in SimPhoNy Remote 0.9.0/1.0.0

--- a/jupyterhub/remoteappmanager_config.py
+++ b/jupyterhub/remoteappmanager_config.py
@@ -18,7 +18,7 @@
 # # label. You generally should not change this unless you have multiple
 # # installations of simphony-remote all using the same docker host.
 #
-# docker_realm = "remoteexec"
+# docker_realm = "whatever"
 #
 # # TLS configuration
 # # -----------------

--- a/jupyterhub/remoteappmanager_config.py
+++ b/jupyterhub/remoteappmanager_config.py
@@ -11,6 +11,14 @@
 # # install, the connection uses a unix socket by default.
 #
 # docker_host = "tcp://192.168.99.100:2376"
+
+# # Docker realm is used to identify the containers that are managed by this
+# # particular instance of simphony-remote. It will be the first entry in
+# # the container name, and will also be added as part of a run-time container
+# # label. You generally should not change this unless you have multiple
+# # installations of simphony-remote all using the same docker host.
+#
+# docker_realm = "remoteexec"
 #
 # # TLS configuration
 # # -----------------

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -96,6 +96,7 @@ class BaseApplication(web.Application, LoggingMixin):
         """Initializes the docker container manager."""
 
         return ContainerManager(
+            realm=self.file_config.docker_realm,
             docker_config=self.file_config.docker_config()
         )
 

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -94,7 +94,6 @@ class BaseApplication(web.Application, LoggingMixin):
     @default("container_manager")
     def _container_manager_default(self):
         """Initializes the docker container manager."""
-
         return ContainerManager(
             realm=self.file_config.docker_realm,
             docker_config=self.file_config.docker_config()

--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -45,6 +45,9 @@ class Container(HasTraits):
     #: Must not have an end slash.
     urlpath = Unicode()
 
+    # The docker realm under which the container is running.
+    realm = Unicode()
+
     @validate("urlpath")
     def _urlpath_validate(self, proposal):
         if proposal['value'].endswith('/'):
@@ -151,6 +154,7 @@ class Container(HasTraits):
         kwargs["url_id"] = labels.get(SIMPHONY_NS_RUNINFO.url_id) or ""
         kwargs["user"] = labels.get(SIMPHONY_NS_RUNINFO.user) or ""
         kwargs["urlpath"] = labels.get(SIMPHONY_NS_RUNINFO.urlpath) or ""
+        kwargs["realm"] = labels.get(SIMPHONY_NS_RUNINFO.realm) or ""
 
         try:
             return cls(**kwargs)

--- a/remoteappmanager/docker/docker_labels.py
+++ b/remoteappmanager/docker/docker_labels.py
@@ -68,6 +68,11 @@ SIMPHONY_NS_RUNINFO = DockerLabelNamespace(
         # https://host:8000/user/username/containers/12345/
         # it will be /user/username/containers/12345/.
         # This is also the url that's been added to the reverse proxy.
-        "urlpath"
+        "urlpath",
+        # The docker realm this container belongs to.
+        # Useful to differentiate docker containers that belong to other
+        # instances of simphony-remote, or simply containers that do not
+        # belong to an instance at all
+        "realm"
     ],
 )

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -20,6 +20,7 @@ class TestContainer(TestCase):
             'Labels': {SIMPHONY_NS.ui_name: 'Empty Ubuntu',
                        SIMPHONY_NS_RUNINFO.user: 'user',
                        SIMPHONY_NS_RUNINFO.url_id: "8e2fe66d5de74db9bbab50c0d2f92b33",  # noqa
+                       SIMPHONY_NS_RUNINFO.realm: "myrealm",
                        SIMPHONY_NS_RUNINFO.urlpath: "/user/username/containers/whatever"},  # noqa
             'Names': ['/remoteexec-user-empty-ubuntu_3Alatest'],
             'Ports': [{'IP': '0.0.0.0',
@@ -38,7 +39,7 @@ class TestContainer(TestCase):
         self.assertEqual(container.host_url, "http://123.45.67.89:31337")
 
     def test_from_docker_dict_with_public_port(self):
-        '''Test convertion from "docker ps" to Container with public port'''
+        """Test convertion from "docker ps" to Container with public port"""
         # With public port
         container_dict = self.good_container_dict
 
@@ -53,7 +54,8 @@ class TestContainer(TestCase):
             ip='0.0.0.0',
             port=32823,
             url_id="8e2fe66d5de74db9bbab50c0d2f92b33",
-            urlpath="/user/username/containers/whatever"
+            urlpath="/user/username/containers/whatever",
+            realm="myrealm"
         )
 
         assert_containers_equal(self, actual, expected)
@@ -65,6 +67,14 @@ class TestContainer(TestCase):
 
         with self.assertRaises(ValueError):
             Container.from_docker_dict(self.good_container_dict)
+
+    def test_no_realm(self):
+        labels = self.good_container_dict["Labels"]
+        labels[SIMPHONY_NS_RUNINFO.realm] = ""
+
+        container = Container.from_docker_dict(self.good_container_dict)
+
+        self.assertEqual(container.realm, "")
 
     def test_from_docker_dict_without_public_port(self):
         '''Test convertion from "docker ps" to Container with public port'''

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -22,7 +22,7 @@ class TestContainer(TestCase):
                        SIMPHONY_NS_RUNINFO.url_id: "8e2fe66d5de74db9bbab50c0d2f92b33",  # noqa
                        SIMPHONY_NS_RUNINFO.realm: "myrealm",
                        SIMPHONY_NS_RUNINFO.urlpath: "/user/username/containers/whatever"},  # noqa
-            'Names': ['/remoteexec-user-empty-ubuntu_3Alatest'],
+            'Names': ['/myrealm-user-empty-ubuntu_3Alatest'],
             'Ports': [{'IP': '0.0.0.0',
                        'PrivatePort': 8888,
                        'PublicPort': 32823,
@@ -47,7 +47,7 @@ class TestContainer(TestCase):
         actual = Container.from_docker_dict(container_dict)
         expected = Container(
             docker_id='248e45e717cd740ae763a1c565',
-            name='/remoteexec-user-empty-ubuntu_3Alatest',
+            name='/myrealm-user-empty-ubuntu_3Alatest',
             image_name='empty-ubuntu:latest',
             image_id='sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
             user="user",
@@ -77,7 +77,7 @@ class TestContainer(TestCase):
         self.assertEqual(container.realm, "")
 
     def test_from_docker_dict_without_public_port(self):
-        '''Test convertion from "docker ps" to Container with public port'''
+        """Test convertion from "docker ps" to Container with public port"""
         client = create_docker_client(container_ids=('container_id1',),
                                       container_names=('container_name1',),
                                       container_ports=([{'IP': '0.0.0.0',
@@ -97,6 +97,7 @@ class TestContainer(TestCase):
             port=80,
             url_id="url_id",
             mapping_id="mapping_id",
+            realm="myrealm",
             urlpath="/user/username/containers/url_id"
         )
 
@@ -109,7 +110,7 @@ class TestContainer(TestCase):
 
         expected = Container(
             docker_id='container_id1',
-            name='/remoteexec-username-mapping_5Fid',
+            name='/myrealm-username-mapping_5Fid',
             image_name='image_name1',
             image_id='image_id1',
             user="user_name",
@@ -117,6 +118,7 @@ class TestContainer(TestCase):
             port=666,
             url_id="url_id",
             mapping_id="mapping_id",
+            realm="myrealm",
             urlpath="/user/username/containers/url_id"
         )
 

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -282,3 +282,13 @@ class TestContainerManager(AsyncTestCase):
         self.assertEqual(
             mock_client.create_container.call_args[1]["environment"]["FOO"],
             "bar")
+
+    @gen_test
+    def test_different_realm(self):
+        manager = ContainerManager(docker_config={},
+                                   realm="anotherrealm")
+        manager._docker_client._sync_client = create_docker_client()
+
+        result = yield manager.containers_from_mapping_id("user_name",
+                                                          "mapping_id")
+        self.assertEqual(result, [])

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -292,3 +292,16 @@ class TestContainerManager(AsyncTestCase):
         result = yield manager.containers_from_mapping_id("user_name",
                                                           "mapping_id")
         self.assertEqual(result, [])
+
+        result = yield manager.running_containers()
+        self.assertEqual(result, [])
+
+    @gen_test
+    def test_not_stopping_if_different_realm(self):
+        manager = ContainerManager(docker_config={},
+                                   realm="anotherrealm")
+        manager._docker_client._sync_client = create_docker_client()
+        yield manager.stop_and_remove_container("container_id1")
+
+        self.assertFalse(self.mock_docker_client.stop.called)
+        self.assertFalse(self.mock_docker_client.remove_container.called)

--- a/remoteappmanager/file_config.py
+++ b/remoteappmanager/file_config.py
@@ -30,10 +30,16 @@ class FileConfig(HasTraits):
 
     docker_host = Unicode("", help="The docker host to connect to")
 
-    docker_realm = Unicode("remoteexec",
-                           help="The docker realm. Identifies which "
-                                "containers belong to a specific instance of "
-                                "simphony-remote.")
+    #: Docker realm is a label added to containers started by this deployment
+    #: of simphony-remote. You should change this to something unique only if
+    #: your machine is already running other simphony-remote instances, all
+    #: using the same docker server. Failing to do that would allow different
+    #: simphony-remote instances to see (and interact with) each other's
+    #: containers.
+    docker_realm = Unicode(
+        "remoteexec",
+        help="The docker realm. Identifies which containers belong to a "
+             "specific instance of simphony-remote.")
 
     accounting_class = Unicode(
         default_value="remoteappmanager.db.orm.AppAccounting",

--- a/remoteappmanager/file_config.py
+++ b/remoteappmanager/file_config.py
@@ -30,6 +30,11 @@ class FileConfig(HasTraits):
 
     docker_host = Unicode("", help="The docker host to connect to")
 
+    docker_realm = Unicode("remoteexec",
+                           help="The docker realm. Identifies which "
+                                "containers belong to a specific instance of "
+                                "simphony-remote.")
+
     accounting_class = Unicode(
         default_value="remoteappmanager.db.orm.AppAccounting",
         help="The import path to a subclass of ABCAccounting")

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -17,8 +17,8 @@ FAKE_IMAGE_NAMES = ('image_name1', 'image_name2')
 
 FAKE_CONTAINER_IDS = ('container_id1', 'container_id2', 'container_id3')
 
-FAKE_CONTAINER_NAMES = ('remoteexec-username-mapping_5Fid',
-                        'remoteexec-username-mapping_5Fid_5Fexited',
+FAKE_CONTAINER_NAMES = ('myrealm-username-mapping_5Fid',
+                        'myrealm-username-mapping_5Fid_5Fexited',
                         'remoteexec-username-mapping_5Fid_5Fstopped')
 
 
@@ -77,6 +77,7 @@ def get_fake_container_labels(num=3):
     samples = cycle(({SIMPHONY_NS_RUNINFO.user: 'user_name',
                       SIMPHONY_NS_RUNINFO.mapping_id: 'mapping_id',
                       SIMPHONY_NS_RUNINFO.url_id: 'url_id',
+                      SIMPHONY_NS_RUNINFO.realm: 'myrealm',
                       SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/url_id'},  # noqa
                      {SIMPHONY_NS_RUNINFO.user: 'user_name'},
                      {}))

--- a/remoteappmanager/tests/test_file_config.py
+++ b/remoteappmanager/tests/test_file_config.py
@@ -17,6 +17,7 @@ tls_ca = '~/.docker/machine/machines/default/ca.pem'
 tls_cert = '~/.docker/machine/machines/default/cert.pem'
 tls_key = '~/.docker/machine/machines/default/key.pem'
 docker_host = "tcp://192.168.99.100:2376"
+docker_realm = "myrealm"
 '''
 
 GOOD_ACCOUNTING_CONFIG = '''
@@ -68,6 +69,9 @@ class TestFileConfig(TempMixin, unittest.TestCase):
 
         config = FileConfig()
         config.parse_config(self.config_file)
+
+        self.assertEqual(config.docker_host, "https://192.168.99.100:2376")
+        self.assertEqual(config.docker_realm, "myrealm")
 
     def test_tls_no_verify(self):
         docker_config_tls = textwrap.dedent('''
@@ -182,6 +186,5 @@ class TestFileConfig(TempMixin, unittest.TestCase):
         config = FileConfig()
         docker_config = config.docker_config()
 
-        client = docker.Client(**docker_config)
-
-        self.assertIsNotNone(client.info())
+        with contextlib.closing(docker.Client(**docker_config)) as client:
+            self.assertIsNotNone(client.info())


### PR DESCRIPTION
Fixes #349 