### PR TITLE
Establish keyboard focus when the canvas is made visible

### DIFF
--- a/remoteappmanager/static/js/home/views/application_view.js
+++ b/remoteappmanager/static/js/home/views/application_view.js
@@ -55,6 +55,7 @@ define([
         var self = this;
         if (self.visualised_index === self.model.selected_index &&
             self.visualised_status === self.model.status[self.model.selected_index]) {
+            $("iframe").focus();
             return;
         }
         var html = self._render_for_model_state(delayed);
@@ -65,6 +66,7 @@ define([
         } else {
             $(".content").html(html);
         }
+        $("iframe").focus();
     };
    
     ApplicationView.prototype._render_for_model_state = function(delayed) {

--- a/selenium_tests/test_admin_name_header_bug.py
+++ b/selenium_tests/test_admin_name_header_bug.py
@@ -4,22 +4,11 @@ from selenium_tests.selenium_test_base import SeleniumTestBase
 class TestAdminNameHeaderBug(SeleniumTestBase):
     def test_admin_name_header_bug(self):
         driver = self.driver
-        driver.get(self.base_url + "/hub/login")
-        driver.find_element_by_id("username_input").clear()
-        driver.find_element_by_id("username_input").send_keys("admin")
-        driver.find_element_by_id("password_input").clear()
-        driver.find_element_by_id("password_input").send_keys("admin")
-        driver.find_element_by_id("login_submit").click()
-        driver.find_element_by_link_text("Users").click()
-        driver.find_element_by_link_text("Show").click()
-        self.wait_for(lambda:
-            "admin" == driver.find_element_by_css_selector(
-                "span.hidden-xs").text
-        )
-        driver.find_element_by_css_selector("span.hidden-xs").click()
-        driver.find_element_by_css_selector("i.fa.fa-sign-out").click()
-        driver.find_element_by_id("password_input").clear()
-        driver.find_element_by_id("password_input").send_keys("admin")
-
-if __name__ == "__main__":
-    unittest.main()
+        with self.login("admin"):
+            print("hello")
+            driver.find_element_by_link_text("Users").click()
+            driver.find_element_by_link_text("Show").click()
+            self.wait_for(lambda:
+                "admin" == driver.find_element_by_css_selector(
+                    "span.hidden-xs").text
+            )

--- a/selenium_tests/test_start_stop_container.py
+++ b/selenium_tests/test_start_stop_container.py
@@ -1,33 +1,37 @@
 # -*- coding: utf-8 -*-
-from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.support.wait import WebDriverWait
 from selenium_tests.selenium_test_base import SeleniumTestBase
-from selenium.webdriver.support import expected_conditions as EC
 
 
-class TestStartStopContainer(SeleniumTestBase):
+class TestContainerInteraction(SeleniumTestBase):
     def test_start_stop_container(self):
         driver = self.driver
-        driver.get(self.base_url + "/hub/login")
-        driver.find_element_by_id("username_input").clear()
-        driver.find_element_by_id("username_input").send_keys("test")
-        driver.find_element_by_id("password_input").clear()
-        driver.find_element_by_id("password_input").send_keys("test")
-        driver.find_element_by_id("login_submit").click()
+        with self.login():
+            self.wait_for(lambda:
+                driver.find_element_by_css_selector(
+                    "#applist > li > a").text != "Loading")
 
-        self.wait_for(lambda:
-            driver.find_element_by_css_selector("#applist > li > a").text !=
-            "Loading")
+            self.click_by_css_selector("#applist > li > a")
+            self.click_by_css_selector(".start-button")
 
-        self.click_by_css_selector("#applist > li > a")
-        self.click_by_css_selector(".start-button")
-
-        driver.find_element_by_id("application")
-        ActionChains(driver).move_to_element(
-            driver.find_element_by_css_selector("#applist .app-icon")
-            ).click(driver.find_element_by_css_selector(".stop-button")
+            driver.find_element_by_id("application")
+            ActionChains(driver).move_to_element(
+                driver.find_element_by_css_selector("#applist .app-icon")
+                ).click(driver.find_element_by_css_selector(".stop-button")
             ).perform()
 
-        driver.find_element_by_css_selector(".dropdown-toggle").click()
-        driver.find_element_by_id("logout").click()
+    def test_focus(self):
+        driver = self.driver
+        with self.running_container():
+            iframe = driver.find_element_by_css_selector("iframe")
+            self.assertEqual(iframe, self.driver.switch_to.active_element)
+
+            search_box = driver.find_element_by_css_selector(
+                "input.form-control")
+            ActionChains(driver).move_to_element(search_box).click().perform()
+
+            self.assertNotEqual(iframe, self.driver.switch_to.active_element)
+
+            self.click_by_css_selector("#applist > li > a")
+
+            self.assertEqual(iframe, self.driver.switch_to.active_element)


### PR DESCRIPTION
Fixes #347 

Will still not work for clicking on the canvas. Seems to be a limitation of the fact that canvas is inside an iframe, so it has no authority over controlling the focus.

