### PR TITLE
Virtual docker cleanup

### DIFF
--- a/remoteappmanager/cli/tests/test_remoteappdb.py
+++ b/remoteappmanager/cli/tests/test_remoteappdb.py
@@ -7,7 +7,11 @@ from click.testing import CliRunner
 from remoteappmanager.cli.remoteappdb import __main__ as remoteappdb
 from remoteappmanager.tests.temp_mixin import TempMixin
 from remoteappmanager.tests.mocking.virtual.docker_client import (
-    create_docker_client)
+    VirtualDockerClient)
+
+
+def create_docker_client():
+    return VirtualDockerClient.with_containers()
 
 
 class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):

--- a/remoteappmanager/cli/tests/test_remoteappdb.py
+++ b/remoteappmanager/cli/tests/test_remoteappdb.py
@@ -62,13 +62,13 @@ class TestRemoteAppDbCLI(TempMixin, unittest.TestCase):
     @mock.patch('remoteappmanager.cli.remoteappdb.__main__.get_docker_client',  # noqa
                 create_docker_client)
     def test_app_create_with_verify(self):
-        exit_code, output = self._remoteappdb("app create image_id1")
+        exit_code, output = self._remoteappdb("app create simphonyproject/simphony-mayavi:0.6.0")  # noqa
 
         self.assertEqual(exit_code, 0)
 
         # Check that the app is created
         exit_code, output = self._remoteappdb("app list")
-        self.assertIn('image_id1', output)
+        self.assertIn('simphonyproject/simphony-mayavi:0.6.0', output)
 
     @mock.patch('remoteappmanager.cli.remoteappdb.__main__.get_docker_client',  # noqa
                 create_docker_client)

--- a/remoteappmanager/db/tests/test_csv_db.py
+++ b/remoteappmanager/db/tests/test_csv_db.py
@@ -16,9 +16,9 @@ class GoodTable:
 
     #    name,     image, home, view, common, source, target, mode
     records = [
-        ('foo', 'image_1', '1', '1', '0', '', '', ''),
-        ('foo', 'image_2', '1', '1', '1', '/src', '/target', 'ro'),
-        ('username', 'image_1', '0', '0', '0', '/src', '/target', 'ro')]
+        ('markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '1', '1', '0', '', '', ''),  # noqa
+        ('markdoe', 'simphonyproject/ubuntu-image:latest', '1', '1', '1', '/src', '/target', 'ro'),  # noqa
+        ('johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '0', '0', '0', '/src', '/target', 'ro')]  # noqa
 
 
 class BadTableMissingHeaders:
@@ -29,9 +29,9 @@ class BadTableMissingHeaders:
 
     #    name,     image, home, view, common, mode
     records = [
-        ('foo', 'image_1', '1', '1', '0', ''),
-        ('foo', 'image_2', '1', '1', '1', 'ro'),
-        ('username', 'image_1', '0', '0', '0', 'ro')]
+        ('markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '1', '1', '0', ''),  # noqa
+        ('markdoe', 'simphonyproject/ubuntu-image:latest', '1', '1', '1', 'ro'),  # noqa
+        ('johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '0', '0', '0', 'ro')]  # noqa
 
 
 class GoodTableWithDifferentHeaders:
@@ -45,9 +45,9 @@ class GoodTableWithDifferentHeaders:
 
     #  view, common, source, target, mode, name, image, home, extra
     records = [
-        ('1', '0', '', '', '', 'foo', 'image_1', '1', 'anything'),
-        ('1', '1', '/src', '/target', 'ro', 'foo', 'image_2', '1', 'extra'),
-        ('0', '0', '/src', '/target', 'ro', 'username', 'image_1', '0', 'abc')]
+        ('1', '0', '', '', '', 'markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '1', 'anything'),  # noqa
+        ('1', '1', '/src', '/target', 'ro', 'markdoe', 'simphonyproject/ubuntu-image:latest', '1', 'extra'),  # noqa
+        ('0', '0', '/src', '/target', 'ro', 'johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '0', 'abc')]  # noqa
 
 
 def write_csv_file(file_name, headers, records):

--- a/remoteappmanager/db/tests/test_csv_db.py
+++ b/remoteappmanager/db/tests/test_csv_db.py
@@ -72,19 +72,19 @@ class TestCSVAccounting(TempMixin, ABCTestDatabaseInterface,
                                  self.assertApplicationPolicyEqual)
 
     def create_expected_users(self):
-        return (CSVUser(0, 'foo'), CSVUser(1, 'username'))
+        return (CSVUser(0, 'markdoe'), CSVUser(1, 'johndoe'))
 
     def create_expected_configs(self, user):
         mappings = {
-            'foo': (
-                (CSVApplication(id=0, image='image_1'),
+            'markdoe': (
+                (CSVApplication(id=0, image='simphonyproject/simphony-mayavi:0.6.0'),  # noqa
                  CSVApplicationPolicy(allow_home=True,
                                       allow_view=True,
                                       allow_common=False,
                                       volume_source=None,
                                       volume_target=None,
                                       volume_mode=None)),
-                (CSVApplication(id=1, image='image_2'),
+                (CSVApplication(id=1, image='simphonyproject/ubuntu-image:latest'),  # noqa
                  CSVApplicationPolicy(allow_home=True,
                                       allow_view=True,
                                       allow_common=True,
@@ -92,8 +92,8 @@ class TestCSVAccounting(TempMixin, ABCTestDatabaseInterface,
                                       volume_target='/target',
                                       volume_mode='ro'))
                 ),
-            'username': (
-                (CSVApplication(id=0, image='image_1'),
+            'johndoe': (
+                (CSVApplication(id=0, image='simphonyproject/simphony-mayavi:0.6.0'),  # noqa
                  CSVApplicationPolicy(allow_home=False,
                                       allow_view=False,
                                       allow_common=False,
@@ -109,13 +109,13 @@ class TestCSVAccounting(TempMixin, ABCTestDatabaseInterface,
     def test_get_user(self):
         accounting = self.create_accounting()
 
-        user = accounting.get_user(user_name='foo')
+        user = accounting.get_user(user_name='markdoe')
         self.assertIsInstance(user, CSVUser)
-        self.assertEqual(user.name, 'foo')
+        self.assertEqual(user.name, 'markdoe')
 
         user = accounting.get_user(id=0)
         self.assertIsInstance(user, CSVUser)
-        self.assertEqual(user.name, 'foo')
+        self.assertEqual(user.name, 'markdoe')
 
         user = accounting.get_user(user_name='unknown')
         self.assertIsNone(user)

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -526,7 +526,6 @@ class ContainerManager(LoggingMixin):
         Note: The container is only stopped if it belongs to the same
         realm.
         """
-        import pdb; pdb.set_trace()
         self.log.info("Stopping container {}".format(container_id))
 
         container_info = yield self._get_container_info(container_id)

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -526,7 +526,7 @@ class ContainerManager(LoggingMixin):
         Note: The container is only stopped if it belongs to the same
         realm.
         """
-
+        import pdb; pdb.set_trace()
         self.log.info("Stopping container {}".format(container_id))
 
         container_info = yield self._get_container_info(container_id)

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -256,7 +256,13 @@ class ContainerManager(LoggingMixin):
                                                 mapping_id=mapping_id,
                                                 user_name=user_name)
         if len(containers) > 1:
-            raise MultipleResultsFound()
+            raise MultipleResultsFound(
+                "Found {} results for request {}, {}, {}".format(
+                    len(containers),
+                    url_id,
+                    mapping_id,
+                    user_name
+                ))
 
         if len(containers) == 1:
             return containers[0]

--- a/remoteappmanager/docker/tests/test_async_docker_client.py
+++ b/remoteappmanager/docker/tests/test_async_docker_client.py
@@ -4,7 +4,7 @@ from docker.utils import kwargs_from_env
 
 from remoteappmanager.docker.async_docker_client import AsyncDockerClient
 from remoteappmanager.tests.mocking.virtual.docker_client import (
-    create_docker_client)
+    VirtualDockerClient)
 
 
 class TestAsyncDockerClient(AsyncTestCase):
@@ -27,7 +27,7 @@ class TestAsyncDockerClient(AsyncTestCase):
     @gen_test
     def test_info(self):
         client = AsyncDockerClient()
-        client._sync_client = create_docker_client()
+        client._sync_client = VirtualDockerClient.with_containers()
         response = yield client.info()
         # Test contents of response
         self.assertIsInstance(response, dict)

--- a/remoteappmanager/docker/tests/test_configurables.py
+++ b/remoteappmanager/docker/tests/test_configurables.py
@@ -8,11 +8,13 @@ from remoteappmanager.tests.mocking.virtual.docker_client import (
 class TestConfigurables(unittest.TestCase):
     def setUp(self):
         docker_client = VirtualDockerClient.with_containers()
-        image_dict = docker_client.inspect_image('image_id2')
-        self.image_2 = Image.from_docker_dict(image_dict)
-
-        image_dict = docker_client.inspect_image('image_id1')
+        image_dict = docker_client.inspect_image(
+            'simphonyproject/simphony-mayavi')
         self.image_1 = Image.from_docker_dict(image_dict)
+
+        image_dict = docker_client.inspect_image(
+            'simphonyproject/ubuntu-image')
+        self.image_2 = Image.from_docker_dict(image_dict)
 
     def test_resolution(self):
         self.assertTrue(Resolution.supported_by(self.image_1))

--- a/remoteappmanager/docker/tests/test_configurables.py
+++ b/remoteappmanager/docker/tests/test_configurables.py
@@ -1,13 +1,13 @@
 import unittest
 from remoteappmanager.docker.configurables import Resolution, for_image
 from remoteappmanager.docker.image import Image
-from remoteappmanager.tests.mocking.virtual.docker_client import \
-    create_docker_client
+from remoteappmanager.tests.mocking.virtual.docker_client import (
+    VirtualDockerClient)
 
 
 class TestConfigurables(unittest.TestCase):
     def setUp(self):
-        docker_client = create_docker_client()
+        docker_client = VirtualDockerClient.with_containers()
         image_dict = docker_client.inspect_image('image_id2')
         self.image_2 = Image.from_docker_dict(image_dict)
 

--- a/remoteappmanager/docker/tests/test_configurables.py
+++ b/remoteappmanager/docker/tests/test_configurables.py
@@ -9,11 +9,11 @@ class TestConfigurables(unittest.TestCase):
     def setUp(self):
         docker_client = VirtualDockerClient.with_containers()
         image_dict = docker_client.inspect_image(
-            'simphonyproject/simphony-mayavi')
+            'simphonyproject/simphony-mayavi:0.6.0')
         self.image_1 = Image.from_docker_dict(image_dict)
 
         image_dict = docker_client.inspect_image(
-            'simphonyproject/ubuntu-image')
+            'simphonyproject/ubuntu-image:latest')
         self.image_2 = Image.from_docker_dict(image_dict)
 
     def test_resolution(self):

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -99,10 +99,10 @@ class TestContainer(TestCase):
     def test_from_docker_dict_inspect_container(self):
         client = VirtualDockerClient.with_containers()
         actual = Container.from_docker_dict(
-            client.inspect_container('container_id1'))
+            client.inspect_container('d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30'))  # noqa
 
         expected = Container(
-            docker_id='container_id1',
+            docker_id='d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30',  # noqa
             name='/myrealm-username-mapping_5Fid',
             image_name='image_name1',
             image_id='image_id1',

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -85,7 +85,7 @@ class TestContainer(TestCase):
         actual = Container.from_docker_dict(container_dict)
         expected = Container(
             docker_id='container_id1',
-            name='/container_name1',
+            name='/myrealm-username-mapping_5Fid',
             image_name='image_name1',
             image_id='image_id1',
             user="user_name",

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -14,22 +14,36 @@ class TestContainer(TestCase):
             'Command': '/startup.sh',
             'Created': 1466756760,
             'HostConfig': {'NetworkMode': 'default'},
-            'Id': '248e45e717cd740ae763a1c565',
+            'Id': 'b55a25bdda5273a4a835dbf7843937daff2f124cd6e39e6546bb0f9e6a84a76c',  # noqa
             'Image': 'empty-ubuntu:latest',
             'ImageID': 'sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
             'Labels': {SIMPHONY_NS.ui_name: 'Empty Ubuntu',
-                       SIMPHONY_NS_RUNINFO.user: 'user',
+                       SIMPHONY_NS_RUNINFO.user: 'johndoe',
                        SIMPHONY_NS_RUNINFO.url_id: "8e2fe66d5de74db9bbab50c0d2f92b33",  # noqa
                        SIMPHONY_NS_RUNINFO.realm: "myrealm",
-                       SIMPHONY_NS_RUNINFO.mapping_id: "mapping_id",
-                       SIMPHONY_NS_RUNINFO.urlpath: "/user/username/containers/8e2fe66d5de74db9bbab50c0d2f92b33"},  # noqa
-            'Names': ['/myrealm-user-empty-ubuntu_3Alatest'],
+                       SIMPHONY_NS_RUNINFO.mapping_id: "492b7c27bb2041278ae851be1c551f4b",  # noqa
+                       SIMPHONY_NS_RUNINFO.urlpath: "/user/johndoe/containers/8e2fe66d5de74db9bbab50c0d2f92b33"},  # noqa
+            'Names': ['/myrealm-johndoe-empty-ubuntu_3Alatest'],
             'Ports': [{'IP': '0.0.0.0',
                        'PrivatePort': 8888,
                        'PublicPort': 32823,
                        'Type': 'tcp'}],
             'State': 'running',
             'Status': 'Up 56 minutes'}
+
+        self.expected = Container(
+            docker_id='b55a25bdda5273a4a835dbf7843937daff2f124cd6e39e6546bb0f9e6a84a76c',  # noqa
+            name='/myrealm-johndoe-empty-ubuntu_3Alatest',
+            image_name='empty-ubuntu:latest',
+            image_id='sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
+            user="johndoe",
+            ip='0.0.0.0',
+            port=32823,
+            mapping_id="492b7c27bb2041278ae851be1c551f4b",
+            url_id="8e2fe66d5de74db9bbab50c0d2f92b33",
+            urlpath="/user/johndoe/containers/8e2fe66d5de74db9bbab50c0d2f92b33",  # noqa
+            realm="myrealm"
+        )
 
     def test_host_url(self):
         container = Container(
@@ -46,19 +60,7 @@ class TestContainer(TestCase):
 
         # Container with public port
         actual = Container.from_docker_dict(container_dict)
-        expected = Container(
-            docker_id='248e45e717cd740ae763a1c565',
-            name='/myrealm-user-empty-ubuntu_3Alatest',
-            image_name='empty-ubuntu:latest',
-            image_id='sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
-            user="user",
-            ip='0.0.0.0',
-            port=32823,
-            mapping_id="mapping_id",
-            url_id="8e2fe66d5de74db9bbab50c0d2f92b33",
-            urlpath="/user/username/containers/8e2fe66d5de74db9bbab50c0d2f92b33",  # noqa
-            realm="myrealm"
-        )
+        expected = self.expected
 
         assert_containers_equal(self, actual, expected)
 
@@ -84,16 +86,8 @@ class TestContainer(TestCase):
 
         # Container without public port
         actual = Container.from_docker_dict(container_dict)
-        expected = Container(
-            docker_id='248e45e717cd740ae763a1c565',
-            name='/myrealm-user-empty-ubuntu_3Alatest',
-            image_name='empty-ubuntu:latest',
-            image_id='sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
-            user="user",
-            ip='0.0.0.0',
-            port=80,
-            url_id="8e2fe66d5de74db9bbab50c0d2f92b33"
-        )
+        expected = self.expected
+        expected.port = 80
         assert_containers_equal(self, actual, expected)
 
     def test_from_docker_dict_inspect_container(self):
@@ -103,16 +97,16 @@ class TestContainer(TestCase):
 
         expected = Container(
             docker_id='d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30',  # noqa
-            name='/myrealm-username-mapping_5Fid',
-            image_name='image_name1',
-            image_id='image_id1',
-            user="username",
+            name="/myrealm-johndoe-5b34ce60d95742fa828cdced12b4c342-ascvbefsda",  # noqa
+            image_name='simphonyproject/simphony-mayavi:0.6.0',
+            image_id='sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',  # noqa
+            user="johndoe",
             ip='0.0.0.0',
             port=666,
-            url_id="url_id",
-            mapping_id="mapping_id",
+            url_id="20dcb84cdbea4b1899447246789093d0",
+            mapping_id="5b34ce60d95742fa828cdced12b4c342",
             realm="myrealm",
-            urlpath="/user/username/containers/8e2fe66d5de74db9bbab50c0d2f92b33"  # noqa
+            urlpath="/user/johndoe/containers/20dcb84cdbea4b1899447246789093d0"  # noqa
         )
 
         assert_containers_equal(self, actual, expected)

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -102,7 +102,7 @@ class TestContainer(TestCase):
         docker_dict = {'Id': 'container_id1',
                        'Config': {
                            'Labels': {
-                               'eu.simphony-project.docker.ui_name': 'Mayavi 4.4.4',
+                               'eu.simphony-project.docker.ui_name': 'Mayavi 4.4.4',  # noqa
                                'eu.simphony-project.docker.env.x11-depth': '',
                                'eu.simphony-project.docker.type': 'vncapp',
                                'eu.simphony-project.docker.env.x11-height': '',

--- a/remoteappmanager/docker/tests/test_container.py
+++ b/remoteappmanager/docker/tests/test_container.py
@@ -16,7 +16,7 @@ class TestContainer(TestCase):
             'HostConfig': {'NetworkMode': 'default'},
             'Id': 'b55a25bdda5273a4a835dbf7843937daff2f124cd6e39e6546bb0f9e6a84a76c',  # noqa
             'Image': 'empty-ubuntu:latest',
-            'ImageID': 'sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
+            'ImageID': 'sha256:14f98aa95d388cabbc4aa44b4b547b729c64673f51fc3321dccdf42fee20f01a',  # noqa
             'Labels': {SIMPHONY_NS.ui_name: 'Empty Ubuntu',
                        SIMPHONY_NS_RUNINFO.user: 'johndoe',
                        SIMPHONY_NS_RUNINFO.url_id: "8e2fe66d5de74db9bbab50c0d2f92b33",  # noqa
@@ -35,7 +35,7 @@ class TestContainer(TestCase):
             docker_id='b55a25bdda5273a4a835dbf7843937daff2f124cd6e39e6546bb0f9e6a84a76c',  # noqa
             name='/myrealm-johndoe-empty-ubuntu_3Alatest',
             image_name='empty-ubuntu:latest',
-            image_id='sha256:f4610c7580b8f0a9a25086b6287d0069fb8a',
+            image_id='sha256:14f98aa95d388cabbc4aa44b4b547b729c64673f51fc3321dccdf42fee20f01a',  # noqa
             user="johndoe",
             ip='0.0.0.0',
             port=32823,

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -236,7 +236,7 @@ class TestContainerManager(AsyncTestCase):
 
             yield self.manager.start_container("johndoe",
                                                "simphonyproject/simphony-mayavi:0.6.0",  # noqa
-                                               "5b34ce60d95742fa828cdced12b4c342",
+                                               "5b34ce60d95742fa828cdced12b4c342",  # noqa
                                                "/foo/bar",
                                                volumes,
                                                )

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -28,12 +28,12 @@ class TestContainerManager(AsyncTestCase):
         mock_client = self.mock_docker_client
         with mock.patch.object(mock_client, "start",
                                wraps=mock_client.start), \
-             mock.patch.object(mock_client, "stop",
-                               wraps=mock_client.stop), \
-             mock.patch.object(mock_client, "create_container",
-                               wraps=mock_client.create_container), \
-             mock.patch.object(mock_client, "remove_container",
-                               wraps=mock_client.remove_container):
+            mock.patch.object(mock_client, "stop",
+                              wraps=mock_client.stop), \
+            mock.patch.object(mock_client, "create_container",
+                              wraps=mock_client.create_container), \
+            mock.patch.object(mock_client, "remove_container",
+                              wraps=mock_client.remove_container):
 
             result = yield self.manager.start_container(
                 "username",
@@ -46,10 +46,13 @@ class TestContainerManager(AsyncTestCase):
             self.assertTrue(mock_client.start.called)
             self.assertTrue(mock_client.create_container.called)
 
-            runinfo_labels = mock_client.create_container.call_args[1]["labels"]
+            runinfo_labels = mock_client.create_container.call_args[1][
+                "labels"]
 
-            self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.user], "username")
-            self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.realm], "myrealm")
+            self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.user],
+                             "username")
+            self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.realm],
+                             "myrealm")
             self.assertIn(SIMPHONY_NS_RUNINFO.url_id, runinfo_labels)
             self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.mapping_id],
                              "new_mapping_id")
@@ -253,10 +256,10 @@ class TestContainerManager(AsyncTestCase):
 
         with mock.patch.object(docker_client, "stop",
                                wraps=docker_client.stop), \
-             mock.patch.object(docker_client, "remove_container",
-                               wraps=docker_client.remove_container), \
-             mock.patch.object(docker_client, "start",
-                               side_effect=raiser):
+            mock.patch.object(docker_client, "remove_container",
+                              wraps=docker_client.remove_container), \
+            mock.patch.object(docker_client, "start",
+                              side_effect=raiser):
 
             self.assertFalse(self.mock_docker_client.stop.called)
             self.assertFalse(self.mock_docker_client.remove_container.called)
@@ -282,10 +285,10 @@ class TestContainerManager(AsyncTestCase):
 
         with mock.patch.object(docker_client, "stop",
                                wraps=docker_client.stop), \
-             mock.patch.object(docker_client, "remove_container",
-                               wraps=docker_client.remove_container), \
-             mock.patch.object(docker_client, "port",
-                               side_effect=raiser):
+            mock.patch.object(docker_client, "remove_container",
+                              wraps=docker_client.remove_container), \
+            mock.patch.object(docker_client, "port",
+                              side_effect=raiser):
 
             self.manager._docker_client.port = mock.Mock(side_effect=raiser)
 

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -70,20 +70,21 @@ class TestContainerManager(AsyncTestCase):
     def test_find_from_mapping_id(self):
         """ Test containers_for_mapping_id returns a list of Container """
         result = yield self.manager.find_containers(
-            user_name="username",
-            mapping_id="mapping_id")
+            user_name="johndoe",
+            mapping_id="5b34ce60d95742fa828cdced12b4c342")
 
-        expected = Container(docker_id='container_id1',
-                             mapping_id="mapping_id",
-                             name='/myrealm-username-mapping_5Fid',
-                             image_name='image_name1',  # noqa
-                             user="username",
-                             image_id='image_id1',
+        expected = Container(docker_id='d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30',  # noqa
+                             mapping_id="5b34ce60d95742fa828cdced12b4c342",
+                             name="/myrealm-johndoe-5b34ce60d95742fa828cdced12b4c342-ascvbefsda",  # noqa
+                             image_name='simphonyproject/simphony-mayavi:0.6.0',  # noqa
+                             user="johndoe",
+                             image_id="sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", # noqa
                              ip='127.0.0.1',
                              port=666,
-                             url_id='url_id',
+                             url_id='20dcb84cdbea4b1899447246789093d0',
                              realm="myrealm",
-                             urlpath="/user/username/containers/url_id")
+                             urlpath="/user/johndoe/containers/20dcb84cdbea4b1899447246789093d0"  # noqa
+                             )
 
         self.assertEqual(len(result), 1)
         utils.assert_containers_equal(self, result[0], expected)
@@ -92,18 +93,19 @@ class TestContainerManager(AsyncTestCase):
     def test_find_from_url_id(self):
         """ Test containers_for_mapping_id returns a list of Container """
         result = yield self.manager.find_container(
-            url_id="url_id")
-        expected = Container(docker_id='container_id1',
-                             mapping_id="mapping_id",
-                             name='/myrealm-username-mapping_5Fid',
-                             image_name='image_name1',  # noqa
-                             user="username",
-                             image_id='image_id1',
+            url_id="20dcb84cdbea4b1899447246789093d0")
+
+        expected = Container(docker_id='d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30',  # noqa
+                             mapping_id="5b34ce60d95742fa828cdced12b4c342",
+                             name="/myrealm-johndoe-5b34ce60d95742fa828cdced12b4c342-ascvbefsda",  # noqa
+                             image_name='simphonyproject/simphony-mayavi:0.6.0',  # noqa
+                             user="johndoe",
+                             image_id="sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824", # noqa
                              ip='127.0.0.1',
                              port=666,
-                             url_id='url_id',
+                             url_id='20dcb84cdbea4b1899447246789093d0',
                              realm="myrealm",
-                             urlpath="/user/username/containers/url_id",
+                             urlpath="/user/johndoe/containers/20dcb84cdbea4b1899447246789093d0"  # noqa
                              )
 
         utils.assert_containers_equal(self, result, expected)
@@ -168,8 +170,8 @@ class TestContainerManager(AsyncTestCase):
         with mock.patch.object(docker_client, "stop",
                                wraps=docker_client.stop):
 
-            f1 = self.manager.stop_and_remove_container("container_id1")
-            f2 = self.manager.stop_and_remove_container("container_id1")
+            f1 = self.manager.stop_and_remove_container("d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30")  # noqa
+            f2 = self.manager.stop_and_remove_container("d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30")  # noqa
 
             yield f1
 
@@ -190,10 +192,10 @@ class TestContainerManager(AsyncTestCase):
                               wraps=mock_client.remove_container):
 
             result = yield self.manager.start_container(
-                "user_name",
-                "image_name1",
-                "mapping_id",
-                "/base/url",
+                "johndoe",
+                "simphonyproject/simphony-mayavi:0.6.0",
+                "5b34ce60d95742fa828cdced12b4c342",
+                "/users/johndoe/containers/random_value",
                 None,
                 None)
             self.assertTrue(mock_client.start.called)
@@ -205,13 +207,13 @@ class TestContainerManager(AsyncTestCase):
 
     @gen_test
     def test_image(self):
-        image = yield self.manager.image('image_name1')
+        image = yield self.manager.image('simphonyproject/simphony-mayavi:0.6.0')  # noqa
         self.assertIsInstance(image, Image)
         self.assertEqual(image.description,
                          'Ubuntu machine with mayavi preinstalled')
         self.assertEqual(image.icon_128, "")
         self.assertEqual(image.ui_name, "Mayavi 4.4.4")
-        self.assertEqual(image.docker_id, 'image_id1')
+        self.assertEqual(image.docker_id, "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")  # noqa
 
         image = yield self.manager.image("whatev")
         self.assertIsNone(image)
@@ -232,9 +234,9 @@ class TestContainerManager(AsyncTestCase):
             volumes[good_path] = {'bind': '/target_vol3',
                                   'mode': 'ro'}
 
-            yield self.manager.start_container("username",
-                                               "image_id1",
-                                               "mapping_id",
+            yield self.manager.start_container("johndoe",
+                                               "simphonyproject/simphony-mayavi:0.6.0",  # noqa
+                                               "5b34ce60d95742fa828cdced12b4c342",
                                                "/foo/bar",
                                                volumes,
                                                )
@@ -268,10 +270,10 @@ class TestContainerManager(AsyncTestCase):
             self.assertFalse(self.mock_docker_client.remove_container.called)
 
             with self.assertRaisesRegex(Exception, 'Boom!'):
-                yield self.manager.start_container("username",
-                                                   "image_id1",
-                                                   "mapping_id",
-                                                   "/base/url",
+                yield self.manager.start_container("johndoe",
+                                                   "simphonyproject/simphony-mayavi:0.6.0",  # noqa
+                                                   "5b34ce60d95742fa828cdced12b4c342",  # noqa
+                                                   "/users/johndoe/containers/4273750ddce3454283a5b1817526260b/",  # noqa
                                                    None,
                                                    None)
 
@@ -296,10 +298,10 @@ class TestContainerManager(AsyncTestCase):
             self.manager._docker_client.port = mock.Mock(side_effect=raiser)
 
             with self.assertRaisesRegex(Exception, 'Boom!'):
-                yield self.manager.start_container("username",
-                                                   "image_id1",
-                                                   "mapping_id",
-                                                   "/base/url",
+                yield self.manager.start_container("johndoe",
+                                                   "simphonyproject/simphony-mayavi:0.6.0",  # noqa
+                                                   "4273750ddce3454283a5b1817526260b",  # noqa
+                                                   "/users/johndoe/containers/3b83f81f2e4544e6aa1493b50202f8eb",  # noqa
                                                    None,
                                                    None)
 
@@ -317,10 +319,10 @@ class TestContainerManager(AsyncTestCase):
             }
 
             yield self.manager.start_container(
-                "username",
-                "image_name1",
-                "mapping_id",
-                "/base/url",
+                "johndoe",
+                "simphonyproject/simphony-mayavi:0.6.0",
+                "4273750ddce3454283a5b1817526260b",
+                "/users/johndoe/containers/3b83f81f2e4544e6aa1493b50202f8eb",
                 None,
                 environment)
 
@@ -337,7 +339,7 @@ class TestContainerManager(AsyncTestCase):
             VirtualDockerClient.with_containers()
 
         result = yield manager.find_container(
-            user_name="user_name", mapping_id="mapping_id")
+            user_name="johndoe", mapping_id="5b34ce60d95742fa828cdced12b4c342")
         self.assertIsNone(result)
 
         result = yield manager.find_containers()
@@ -349,7 +351,7 @@ class TestContainerManager(AsyncTestCase):
         self.mock_docker_client.remove_container = mock.Mock()
         manager = ContainerManager(docker_config={},
                                    realm="anotherrealm")
-        yield manager.stop_and_remove_container("container_id1")
+        yield manager.stop_and_remove_container("d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30")  # noqa
 
         self.assertFalse(self.mock_docker_client.stop.called)
         self.assertFalse(self.mock_docker_client.remove_container.called)

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -36,10 +36,10 @@ class TestContainerManager(AsyncTestCase):
                               wraps=mock_client.remove_container):
 
             result = yield self.manager.start_container(
-                "username",
-                'image_id1',
-                "new_mapping_id",
-                "/base/url",
+                "johndoe",
+                'simphonyproject/simphony-mayavi:0.6.0',
+                "63dce9335bca49798bbb93146ad07c66",
+                "/user/johndoe/containers/cbeb652678244ed1aa5f68735abb4868",
                 None,
                 None)
 
@@ -50,12 +50,12 @@ class TestContainerManager(AsyncTestCase):
                 "labels"]
 
             self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.user],
-                             "username")
+                             "johndoe")
             self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.realm],
                              "myrealm")
             self.assertIn(SIMPHONY_NS_RUNINFO.url_id, runinfo_labels)
             self.assertEqual(runinfo_labels[SIMPHONY_NS_RUNINFO.mapping_id],
-                             "new_mapping_id")
+                             "63dce9335bca49798bbb93146ad07c66")
 
             self.assertIsInstance(result, Container)
             self.assertFalse(mock_client.stop.called)
@@ -139,17 +139,17 @@ class TestContainerManager(AsyncTestCase):
         # we yield them
         with mock.patch.object(self.mock_docker_client, "start",
                                wraps=self.mock_docker_client.start):
-            f1 = self.manager.start_container("username",
-                                              "image_id1",
-                                              "mapping_id",
-                                              "/foo/bar",
+            f1 = self.manager.start_container("johndoe",
+                                              "simphonyproject/simphony-mayavi:0.6.0",  # noqa
+                                              "76cd29a4d61f4ddc95fa633347934807",  # noqa
+                                              "/user/johndoe/containers/4b9a34d803c74013939d8df05eef9262",  # noqa
                                               None,
                                               )
 
-            f2 = self.manager.start_container("username",
-                                              "image_id1",
-                                              "mapping_id",
-                                              "/foo/baz",
+            f2 = self.manager.start_container("johndoe",
+                                              "simphonyproject/simphony-mayavi:0.6.0",  # noqa
+                                              "76cd29a4d61f4ddc95fa633347934807",  # noqa
+                                              "/user/johndoe/containers/a2612a5a12074ce99ece1c2888fe34c0",  # noqa
                                               None,
                                               )
 

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -300,10 +300,10 @@ class TestContainerManager(AsyncTestCase):
 
     @gen_test
     def test_not_stopping_if_different_realm(self):
+        self.mock_docker_client.stop = mock.Mock()
+        self.mock_docker_client.remove_container = mock.Mock()
         manager = ContainerManager(docker_config={},
                                    realm="anotherrealm")
-        manager._docker_client._sync_client = \
-            VirtualDockerClient.with_containers()
         yield manager.stop_and_remove_container("container_id1")
 
         self.assertFalse(self.mock_docker_client.stop.called)

--- a/remoteappmanager/docker/tests/test_image.py
+++ b/remoteappmanager/docker/tests/test_image.py
@@ -22,7 +22,7 @@ class TestImage(TestCase):
 
     def test_from_docker_dict_inspect_image(self):
         docker_client = VirtualDockerClient.with_containers()
-        image_dict = docker_client.inspect_image('image_id1')
+        image_dict = docker_client.inspect_image('simphonyproject/simphony-mayavi:0.6.0')  # noqa
 
         labels = image_dict['Config']['Labels']
         # Insert an unpalatable label for the envs.
@@ -47,7 +47,7 @@ class TestImage(TestCase):
 
     def test_missing_image_type(self):
         docker_client = VirtualDockerClient.with_containers()
-        image_dict = docker_client.inspect_image('image_id2')
+        image_dict = docker_client.inspect_image('simphonyproject/ubuntu-image:latest')  # noqa
         image = Image.from_docker_dict(image_dict)
 
         self.assertEqual(image.type, '')

--- a/remoteappmanager/docker/tests/test_image.py
+++ b/remoteappmanager/docker/tests/test_image.py
@@ -3,12 +3,12 @@ from unittest import TestCase
 from remoteappmanager.docker.docker_labels import SIMPHONY_NS, SIMPHONY_NS_ENV
 from remoteappmanager.docker.image import Image
 from remoteappmanager.tests.mocking.virtual.docker_client import (
-    create_docker_client)
+    VirtualDockerClient)
 
 
 class TestImage(TestCase):
     def test_from_docker_dict_images(self):
-        docker_client = create_docker_client()
+        docker_client = VirtualDockerClient.with_containers()
         image_dict = docker_client.images()[0]
         image = Image.from_docker_dict(image_dict)
 
@@ -21,7 +21,7 @@ class TestImage(TestCase):
         self.assertEqual(image.type, 'vncapp')
 
     def test_from_docker_dict_inspect_image(self):
-        docker_client = create_docker_client()
+        docker_client = VirtualDockerClient.with_containers()
         image_dict = docker_client.inspect_image('image_id1')
 
         labels = image_dict['Config']['Labels']
@@ -46,7 +46,7 @@ class TestImage(TestCase):
         })
 
     def test_missing_image_type(self):
-        docker_client = create_docker_client()
+        docker_client = VirtualDockerClient.with_containers()
         image_dict = docker_client.inspect_image('image_id2')
         image = Image.from_docker_dict(image_dict)
 

--- a/remoteappmanager/handlers/admin/tests/test_admin_handlers.py
+++ b/remoteappmanager/handlers/admin/tests/test_admin_handlers.py
@@ -4,7 +4,7 @@ from remoteappmanager.tests.mocking import dummy
 
 class TestBaseAccess(utils.AsyncHTTPTestCase):
     #: which url to poke
-    url = "/user/username"
+    url = "/user/johndoe"
 
     # which string we expect in the body to say it's ok
     body_string = "adminoptions"
@@ -21,7 +21,7 @@ class TestBaseAccess(utils.AsyncHTTPTestCase):
     def test_access(self):
         res = self.fetch(self.url,
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 
@@ -42,29 +42,29 @@ class TestBaseAccess(utils.AsyncHTTPTestCase):
 
 
 class TestApplicationsHandler(TestBaseAccess):
-    url = "/user/username/applications/"
+    url = "/user/johndoe/applications/"
     body_string = "datatable"
 
 
 class TestUsersHandler(TestBaseAccess):
-    url = "/user/username/users/"
+    url = "/user/johndoe/users/"
     body_string = "datatable"
 
 
 class TestContainersHandler(TestBaseAccess):
-    url = "/user/username/containers/"
+    url = "/user/johndoe/containers/"
     body_string = "datatable"
 
 
 class TestAccountingHandler(TestBaseAccess):
-    url = "/user/username/users/0/accounting/"
+    url = "/user/johndoe/users/0/accounting/"
     body_string = "datatable"
 
     def test_unknown_id(self):
         self._app.db.unexistent_user_id = 123422
-        res = self.fetch("/user/username/users/123422/accounting/",
+        res = self.fetch("/user/johndoe/users/123422/accounting/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          })
 
         self.assertEqual(res.code, 404)

--- a/remoteappmanager/handlers/tests/test_base_handler.py
+++ b/remoteappmanager/handlers/tests/test_base_handler.py
@@ -32,9 +32,9 @@ class TestBaseHandlerInvalidAccounting(TestBaseHandler):
         return file_config
 
     def test_home_internal_error(self):
-        res = self.fetch("/user/username/",
+        res = self.fetch("/user/johndoe/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 
@@ -50,9 +50,9 @@ class TestBaseHandlerDatabaseError(TestBaseHandler):
         return file_config
 
     def test_home_internal_error(self):
-        res = self.fetch("/user/username/",
+        res = self.fetch("/user/johndoe/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 
@@ -69,9 +69,9 @@ class TestBaseHandlerGATracking(TestBaseHandler):
         return file_config
 
     def test_ga_tracking(self):
-        res = self.fetch("/user/username/",
+        res = self.fetch("/user/johndoe/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 

--- a/remoteappmanager/handlers/tests/test_home_handler.py
+++ b/remoteappmanager/handlers/tests/test_home_handler.py
@@ -14,9 +14,9 @@ class TestHomeHandler(TempMixin, utils.AsyncHTTPTestCase):
         return app
 
     def test_home(self):
-        res = self.fetch("/user/username/",
+        res = self.fetch("/user/johndoe/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 
@@ -25,9 +25,9 @@ class TestHomeHandler(TempMixin, utils.AsyncHTTPTestCase):
 
     def test_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
-        res = self.fetch("/user/username/",
+        res = self.fetch("/user/johndoe/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 

--- a/remoteappmanager/handlers/tests/test_register_container_handler.py
+++ b/remoteappmanager/handlers/tests/test_register_container_handler.py
@@ -15,18 +15,18 @@ class TestRegisterContainerHandler(TempMixin, utils.AsyncHTTPTestCase):
         return app
 
     def test_absent_url_id(self):
-        res = self.fetch("/user/username/containers/99999/",
+        res = self.fetch("/user/johndoe/containers/99999/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          }
                          )
 
         self.assertEqual(res.code, 404)
 
     def test_present_url_id(self):
-        res = self.fetch("/user/username/containers/url_id",
+        res = self.fetch("/user/johndoe/containers/20dcb84cdbea4b1899447246789093d0/",  # noqa
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          },
                          follow_redirects=False
                          )
@@ -36,9 +36,9 @@ class TestRegisterContainerHandler(TempMixin, utils.AsyncHTTPTestCase):
 
     def test_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
-        res = self.fetch("/user/username/containers/url_id",
+        res = self.fetch("/user/johndoe/containers/url_id",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          },
                          follow_redirects=False
                          )
@@ -51,9 +51,9 @@ class TestRegisterContainerHandler(TempMixin, utils.AsyncHTTPTestCase):
         self._app.reverse_proxy.register = mock_coro_factory(
             side_effect=Exception("BOOM"))
 
-        res = self.fetch("/user/username/containers/url_id",
+        res = self.fetch("/user/johndoe/containers/",
                          headers={
-                             "Cookie": "jupyter-hub-token-username=foo"
+                             "Cookie": "jupyter-hub-token-johndoe=foo"
                          },
                          follow_redirects=False
                          )

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -15,7 +15,7 @@ from remoteappmanager.tests.utils import (
     basic_command_line_config,
     basic_environment_config)
 from remoteappmanager.tests.mocking.virtual.docker_client import (
-    create_docker_client)
+    VirtualDockerClient)
 
 
 class DummyDBApplication(interfaces.ABCApplication):
@@ -224,7 +224,7 @@ def create_container_manager(params=None):
         params = {'docker_config': {}}
 
     manager = ContainerManager(**params)
-    manager._docker_client._sync_client = create_docker_client()
+    manager._docker_client._sync_client = VirtualDockerClient.with_containers()
     return manager
 
 

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -32,11 +32,13 @@ User = namedtuple('User', ('id', 'name'))
 class DummyDBAccounting(interfaces.ABCAccounting):
     def __init__(self):
         self.users = {
-            0: User(0, "username")
+            0: User(0, "johndoe")
         }
 
         self.applications = {
-            0: DummyDBApplication(id=0, image='image_id1'),
+            0: DummyDBApplication(
+                id=0,
+                image='simphonyproject/simphony-mayavi:0.6.0'),
         }
 
         self.policies = {
@@ -44,10 +46,10 @@ class DummyDBAccounting(interfaces.ABCAccounting):
         }
 
         self.accounting = {
-            'mapping_id': (
+            'cbaee2e8ef414f9fb0f1c97416b8aa6c': (
                 self.users[0], self.applications[0], self.policies[0]
             ),
-            'id678': (
+            'b7ca425a51bf40acbd305b3f782714b6': (
                 self.users[0], self.applications[0], self.policies[0]
             )
         }

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -39,6 +39,9 @@ class DummyDBAccounting(interfaces.ABCAccounting):
             0: DummyDBApplication(
                 id=0,
                 image='simphonyproject/simphony-mayavi:0.6.0'),
+            1: DummyDBApplication(
+                id=1,
+                image='simphonyproject/ubuntu-image:latest'),
         }
 
         self.policies = {
@@ -50,7 +53,7 @@ class DummyDBAccounting(interfaces.ABCAccounting):
                 self.users[0], self.applications[0], self.policies[0]
             ),
             'b7ca425a51bf40acbd305b3f782714b6': (
-                self.users[0], self.applications[0], self.policies[0]
+                self.users[0], self.applications[1], self.policies[0]
             )
         }
 

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -108,8 +108,7 @@ class VirtualDockerClient(object):
                        'Status': 'exited',
                        'Dead': False,
                        'OOMKilled': False,
-                       'ExitCode': 0}
-                ,
+                       'ExitCode': 0},
             ),
         ]
 
@@ -304,4 +303,3 @@ class VirtualDockerClient(object):
 
     def _new_id(self):
         return uuid.uuid4().hex
-

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -143,7 +143,12 @@ class VirtualDockerClient(object):
                 name=kwargs["name"],
                 image=kwargs["image"],
                 labels=kwargs.get("labels", {}),
-                ports=[],
+                ports=[{
+                    "IP": "0.0.0.0",
+                    "PublicPort": 666,
+                    "PrivatePort": 8888,
+                    "Type": "tcp",
+                }],
                 state="running",
             )
         )

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import uuid
 import requests
 from collections import namedtuple
@@ -47,15 +48,15 @@ class VirtualDockerClient(object):
         self._images = self._available_images[:]
         self._containers = [
             _Container(
-                id="223c6fc3c5054b7e916ab000ae302df3",
-                name="realm-johndoe-5b34ce60d95742fa828cdced12b4c342",
-                image="simphonyproject/simphony-mayavi",
+                id="d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30",  # noqa
+                name="myrealm-johndoe-5b34ce60d95742fa828cdced12b4c342-ascvbefsda",  # noqa
+                image=self._images[0],
                 labels={
                     SIMPHONY_NS_RUNINFO.user: 'johndoe',
                     SIMPHONY_NS_RUNINFO.mapping_id: '5b34ce60d95742fa828cdced12b4c342',  # noqa
                     SIMPHONY_NS_RUNINFO.url_id: '20dcb84cdbea4b1899447246789093d0',  # noqa
-                    SIMPHONY_NS_RUNINFO.realm: 'realm',
-                    SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/20dcb84cdbea4b1899447246789093d0'  # noqa
+                    SIMPHONY_NS_RUNINFO.realm: 'myrealm',
+                    SIMPHONY_NS_RUNINFO.urlpath: '/user/johndoe/containers/20dcb84cdbea4b1899447246789093d0'  # noqa
                 },
                 ports=[{
                     "IP": "0.0.0.0",
@@ -66,15 +67,15 @@ class VirtualDockerClient(object):
                 state="running",
             ),
             _Container(
-                id="d04eaa6e2c36419cb25b316231a201c0",
-                name="realm-johndoe-6d24a0746a4e409c9b9078b158b8c484",
-                image="simphonyproject/simphony-mayavi",
+                id="7067d5c0c5a62d50fe82538c7a55883cee1ded1d7010520c0be1f9a1ecbf6fed",  # noqa
+                name="myrealm-johndoe-6d24a0746a4e409c9b9078b158b8c484-cvbaeaehu",  # noqa
+                image=self._images[0],
                 labels={
                     SIMPHONY_NS_RUNINFO.user: 'johndoe',
                     SIMPHONY_NS_RUNINFO.mapping_id: 'db3890933e4843f092e954fc5e0caf9e',  # noqa
                     SIMPHONY_NS_RUNINFO.url_id: '90d581268df8428aa91d56a62d83b163',  # noqa
-                    SIMPHONY_NS_RUNINFO.realm: 'realm',
-                    SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/90d581268df8428aa91d56a62d83b163'  # noqa
+                    SIMPHONY_NS_RUNINFO.realm: 'myrealm',
+                    SIMPHONY_NS_RUNINFO.urlpath: '/user/johndoe/containers/90d581268df8428aa91d56a62d83b163'  # noqa
                 },
                 ports=[{
                     "PrivatePort": 8889,
@@ -83,9 +84,9 @@ class VirtualDockerClient(object):
                 state="exited",
             ),
             _Container(
-                id="51e69f95a0d04294a2956c35e2894661",
-                name="realm-johndoe-27d17e78297441fdbe43ee6b8c148a17",
-                image="simphonyproject/simphony-mayavi",
+                id="1ba68b442b12083ce29c8bfa27800f2fca96973b758838de35ba562f385283d5",  # noqa
+                name="myrealm-johndoe-27d17e78297441fdbe43ee6b8c148a17-fgadxcvxqw",  # noqa
+                image=self._images[0],
                 labels={},
                 ports=[{
                     "IP": "0.0.0.0",
@@ -93,6 +94,7 @@ class VirtualDockerClient(object):
                     "PrivatePort": 8888,
                     "Type": "tcp",
                 }],
+
                 state={'Paused': False,
                        'Running': False,
                        'Error': '',
@@ -114,28 +116,38 @@ class VirtualDockerClient(object):
     def inspect_image(self, image_name_or_id):
         image = self._find_image(image_name_or_id)
 
-        return {'Config': {'Cmd': None,
-                           'Domainname': '',
-                           'Entrypoint': ['/startup.sh'],
-                           'ExposedPorts': {'8888/tcp': {}},
-                           'Labels': image.labels},
-                'Id': image.id,
-                'RepoTags': [image.name]}
+        return {
+            'Id': image.id,
+            'RepoTags': [image.name],
+            'Config': {
+                'Cmd': None,
+                'Domainname': '',
+                'Entrypoint': ['/startup.sh'],
+                'ExposedPorts': {port: {} for port in image.exposed_ports},
+                'Labels': image.labels},
+        }
 
     def images(self):
+        """Returns the currently installed images"""
         return [{'Created': '2 days ago',
                  'Id': image.id,
                  'Labels': image.labels,
-                 'RepoTags': [image.name]}
+                 'RepoTags': [image.name]
+                 # Missing keys (omitted because we don't need them now):
+                 # ParentId, RepoDigests, SharedSize, Size, VirtualSize,
+                 # Containers
+                 }
                 for image in self._images]
 
     def create_container(self, *args, **kwargs):
         id = self._new_id()
+        image = self._find_image(kwargs["image"])
+
         self._containers.append(
             _Container(
                 id=id,
                 name=kwargs["name"],
-                image=kwargs["image"],
+                image=image,
                 labels=kwargs.get("labels", {}),
                 ports=[{
                     "IP": "0.0.0.0",
@@ -147,13 +159,13 @@ class VirtualDockerClient(object):
             )
         )
 
-        return {"Id": id}
+        return {"Id": id, "Warnings": None}
 
     def containers(self, *args, **kwargs):
         results = []
 
         for container in self._containers:
-            image = self._find_image(container.image)
+            image = container.image
             if container.state != 'running' and not kwargs.get('all', False):
                 continue
 
@@ -179,15 +191,17 @@ class VirtualDockerClient(object):
                  'Image': image.name,
                  'ImageID': image.id,
                  'Labels': all_labels,
+                 'Mounts': [],
                  'Names': ['/'+container.name],
                  'Ports': container.ports,
-                 'State': container.state})
+                 'State': container.state
+                 })
 
         return results
 
     def inspect_container(self, container_name_or_id):
         container = self._find_container(container_name_or_id)
-        image = self._find_image(container.image)
+        image = container.image
         labels = container.labels
 
         all_labels = image.labels.copy()
@@ -220,29 +234,41 @@ class VirtualDockerClient(object):
     def port(self, container_name_or_id, private_port):
         container = self._find_container(container_name_or_id)
 
-        if container.ports:
-            host_ip = container.ports[0].get('IP', '')
-            host_port = container.ports[0].get('PublicPort', '')
-        else:
-            host_ip = host_port = ''
-
-        return [{'HostIp': host_ip,
-                 'HostPort': host_port}]
+        try:
+            host_ip = container.ports[0]['IP']
+            host_port = container.ports[0]['PublicPort']
+            return [{
+                'HostIp': host_ip,
+                'HostPort': host_port
+            }]
+        except (AttributeError, IndexError, KeyError):
+            return None
 
     def start(self, *args, **kwargs):
-        pass
+        print("VirtualDockerClient.start called with ", args, kwargs)
 
     def stop(self, *args, **kwargs):
-        pass
+        print("VirtualDockerClient.stop called with ", args, kwargs)
 
-    def remove_container(self, *args, **kwargs):
-        pass
+    def remove_container(self, container, *args, **kwargs):
+        container = self._find_container(container)
+        self._containers.remove(container)
 
     def info(self, *args, **kwargs):
-        return {"ID": "something"}
+        return {
+            "ID": 'HYXE:PEQI:7RBH:H5FO:YBA3:V6YK:JIVJ:ALZP:A2YO:ZJ2K:K5BN:JGAC',  # noqa
+            'Containers': len(self._containers),
+            'ContainersPaused': len([x for x in self._containers
+                                     if x.state == "paused"]),
+            'ContainersRunning': len([x for x in self._containers
+                                      if x.state == "running"]),
+            'ContainersStopped': len([x for x in self._containers
+                                      if x.state == "stopped"]),
+
+        }
 
     def create_host_config(self, **kwargs):
-        return {}
+        return {'NetworkMode': 'default'}
 
     # Additional API for convenience's sake
 
@@ -297,14 +323,16 @@ class VirtualDockerClient(object):
         return res
 
     def _new_id(self):
-        return uuid.uuid4().hex
+        """Creates a new random sha256 id."""
+        return hashlib.sha256(uuid.uuid4().hex.encode('utf-8')).hexdigest()
 
     def _init_available_images(self):
-        """Provides the available images"""
+        """Provides the available images. Similar to an "in-memory DockerHub".
+        """
         return [
             _Image(
                 id="sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",  # noqa
-                name='simphonyproject/simphony-mayavi',
+                name='simphonyproject/simphony-mayavi:0.6.0',
                 labels={
                     SIMPHONY_NS.description: 'Ubuntu machine with mayavi preinstalled',  # noqa
                     SIMPHONY_NS.ui_name: 'Mayavi 4.4.4',
@@ -313,17 +341,13 @@ class VirtualDockerClient(object):
                     SIMPHONY_NS_ENV['x11-height']: '',
                     SIMPHONY_NS_ENV['x11-depth']: '',
                 },
-                exposed_ports={
-                    "8888/tcp": {}
-                }
+                exposed_ports=["8888/tcp"]
             ),
             _Image(
                 id="sha256:86acc3c585a1bb1f3be294c2a02fc69a145e5e76d580a5c7c120ff1ecd1a86ab",  # noqa
-                name='simphonyproject/ubuntu-image',
+                name='simphonyproject/ubuntu-image:latest',
                 labels={
                     SIMPHONY_NS.description: 'A vanilla Ubuntu installation',  # noqa
                 },
-                exposed_ports={
-                    "8888/tcp": {}
-                }
+                exposed_ports=["8888/tcp"]
             )]

--- a/remoteappmanager/tests/mocking/virtual/docker_client.py
+++ b/remoteappmanager/tests/mocking/virtual/docker_client.py
@@ -14,57 +14,48 @@ from remoteappmanager.docker.docker_labels import (
 # container manager similarly named entities.
 
 _Image = namedtuple("Image",
-                    field_names="id name labels")
+                    field_names="id name labels exposed_ports")
 _Container = namedtuple("Container",
                         field_names="id name image labels ports state")
 
 
 class VirtualDockerClient(object):
     """A virtual docker client that behaves like the real thing
-    but does nothing. It provides the same interface as dockerpy Client.
-
-    When created, it provides a predefined set of available images.
+    but does nothing on docker. It provides the same interface as dockerpy
+    Client.
     """
+
     def __init__(self):
+        # This entry contains the images that can be installed.
+        # It simulates the hub docker retrieval.
+        self._available_images = self._init_available_images()
+
+        # This contains the images that are currently installed.
         self._images = []
+
+        # This one contains the containers that are currently present
         self._containers = []
 
     @classmethod
     def with_containers(cls):
+        """
+        Alternative constructor.
+        When created, it provides a predefined set of available images.
+        """
         self = cls()
 
-        self._images = [
-            _Image(
-                id="image_id1",
-                name='image_name1',
-                labels={
-                    SIMPHONY_NS.description: 'Ubuntu machine with mayavi preinstalled',  # noqa
-                    SIMPHONY_NS.ui_name: 'Mayavi 4.4.4',
-                    SIMPHONY_NS.type: 'vncapp',
-                    SIMPHONY_NS_ENV['x11-width']: '',
-                    SIMPHONY_NS_ENV['x11-height']: '',
-                    SIMPHONY_NS_ENV['x11-depth']: '',
-                }
-            ),
-            _Image(
-                id="image_id2",
-                name='image_name2',
-                labels={
-                    SIMPHONY_NS.description: 'A vanilla Ubuntu installation',  # noqa
-                }
-            )]
-
+        self._images = self._available_images[:]
         self._containers = [
             _Container(
-                id="container_id1",
-                name="myrealm-username-mapping_5Fid",
-                image="image_id1",
+                id="223c6fc3c5054b7e916ab000ae302df3",
+                name="realm-johndoe-5b34ce60d95742fa828cdced12b4c342",
+                image="simphonyproject/simphony-mayavi",
                 labels={
-                    SIMPHONY_NS_RUNINFO.user: 'user_name',
-                    SIMPHONY_NS_RUNINFO.mapping_id: 'mapping_id',
-                    SIMPHONY_NS_RUNINFO.url_id: 'url_id',
-                    SIMPHONY_NS_RUNINFO.realm: 'myrealm',
-                    SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/url_id'  # noqa
+                    SIMPHONY_NS_RUNINFO.user: 'johndoe',
+                    SIMPHONY_NS_RUNINFO.mapping_id: '5b34ce60d95742fa828cdced12b4c342',  # noqa
+                    SIMPHONY_NS_RUNINFO.url_id: '20dcb84cdbea4b1899447246789093d0',  # noqa
+                    SIMPHONY_NS_RUNINFO.realm: 'realm',
+                    SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/20dcb84cdbea4b1899447246789093d0'  # noqa
                 },
                 ports=[{
                     "IP": "0.0.0.0",
@@ -75,11 +66,15 @@ class VirtualDockerClient(object):
                 state="running",
             ),
             _Container(
-                id="container_id2",
-                name="myrealm-username-mapping_5Fid_5Fexited",
-                image="image_id2",
+                id="d04eaa6e2c36419cb25b316231a201c0",
+                name="realm-johndoe-6d24a0746a4e409c9b9078b158b8c484",
+                image="simphonyproject/simphony-mayavi",
                 labels={
-                    SIMPHONY_NS_RUNINFO.user: 'user_name'
+                    SIMPHONY_NS_RUNINFO.user: 'johndoe',
+                    SIMPHONY_NS_RUNINFO.mapping_id: 'db3890933e4843f092e954fc5e0caf9e',  # noqa
+                    SIMPHONY_NS_RUNINFO.url_id: '90d581268df8428aa91d56a62d83b163',  # noqa
+                    SIMPHONY_NS_RUNINFO.realm: 'realm',
+                    SIMPHONY_NS_RUNINFO.urlpath: '/user/username/containers/90d581268df8428aa91d56a62d83b163'  # noqa
                 },
                 ports=[{
                     "PrivatePort": 8889,
@@ -88,9 +83,9 @@ class VirtualDockerClient(object):
                 state="exited",
             ),
             _Container(
-                id="container_id3",
-                name="remoteexec-username-mapping_5Fid_5Fstopped",
-                image="image_id1",
+                id="51e69f95a0d04294a2956c35e2894661",
+                name="realm-johndoe-27d17e78297441fdbe43ee6b8c148a17",
+                image="simphonyproject/simphony-mayavi",
                 labels={},
                 ports=[{
                     "IP": "0.0.0.0",
@@ -303,3 +298,32 @@ class VirtualDockerClient(object):
 
     def _new_id(self):
         return uuid.uuid4().hex
+
+    def _init_available_images(self):
+        """Provides the available images"""
+        return [
+            _Image(
+                id="sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",  # noqa
+                name='simphonyproject/simphony-mayavi',
+                labels={
+                    SIMPHONY_NS.description: 'Ubuntu machine with mayavi preinstalled',  # noqa
+                    SIMPHONY_NS.ui_name: 'Mayavi 4.4.4',
+                    SIMPHONY_NS.type: 'vncapp',
+                    SIMPHONY_NS_ENV['x11-width']: '',
+                    SIMPHONY_NS_ENV['x11-height']: '',
+                    SIMPHONY_NS_ENV['x11-depth']: '',
+                },
+                exposed_ports={
+                    "8888/tcp": {}
+                }
+            ),
+            _Image(
+                id="sha256:86acc3c585a1bb1f3be294c2a02fc69a145e5e76d580a5c7c120ff1ecd1a86ab",  # noqa
+                name='simphonyproject/ubuntu-image',
+                labels={
+                    SIMPHONY_NS.description: 'A vanilla Ubuntu installation',  # noqa
+                },
+                exposed_ports={
+                    "8888/tcp": {}
+                }
+            )]

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -47,7 +47,7 @@ class TestApplication(TempMixin, testing.AsyncTestCase):
         self.assertIsNotNone(app.reverse_proxy)
         self.assertIsNotNone(app.container_manager)
         self.assertIsNotNone(app.hub)
-        self.assertEqual(app.user.name, "username")
+        self.assertEqual(app.user.name, "johndoe")
         self.assertEqual(app.user.account, None)
 
     def test_error_default_value_with_unimportable_accounting(self):
@@ -88,7 +88,7 @@ class TestApplication(TempMixin, testing.AsyncTestCase):
         self.assertIsNotNone(app.file_config)
         self.assertIsNotNone(app.db)
         self.assertIsNotNone(app.user)
-        self.assertEqual(app.user.name, "username")
+        self.assertEqual(app.user.name, "johndoe")
         self.assertIsInstance(app.user.account, test_csv_db.CSVUser)
 
     def test_start(self):

--- a/remoteappmanager/tests/test_command_line_config.py
+++ b/remoteappmanager/tests/test_command_line_config.py
@@ -25,4 +25,4 @@ class TestCommandLineConfig(unittest.TestCase):
                              value)
 
     def test_base_urlpath(self):
-        self.assertEqual(self.config.base_urlpath, "/user/username/")
+        self.assertEqual(self.config.base_urlpath, "/user/johndoe/")

--- a/remoteappmanager/tests/utils.py
+++ b/remoteappmanager/tests/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import sys
 import socket
+import functools
 
 import tornado.netutil
 import tornado.testing
@@ -138,3 +139,21 @@ def assert_containers_equal(test_case, actual, expected):
         if getattr(actual, name) != getattr(expected, name):
             message = '{!r} is not identical to the expected {!r}.'
             test_case.fail(message.format(actual, expected))
+
+
+def probe(f):
+    """Wraps a function/method to add a probe we can check after the call.
+    Kind of like mock, but preserves the current behavior."""
+
+    @functools.wraps(f)
+    def _f(*args, **kwargs):
+        _f.called = True
+        _f.call_count += 1
+
+        return f(*args, **kwargs)
+
+    _f.called = False
+    _f.call_count = 0
+
+    return _f
+

--- a/remoteappmanager/tests/utils.py
+++ b/remoteappmanager/tests/utils.py
@@ -15,10 +15,10 @@ from remoteappmanager.utils import remove_quotes
 
 # A set of viable start arguments. As they would arrive from outside
 arguments = {
-    "user": "username",
+    "user": "johndoe",
     "port": 57022,
-    "cookie-name": "jupyter-hub-token-username",
-    "base-urlpath": "\"/user/username/\"",
+    "cookie-name": "jupyter-hub-token-johndoe",
+    "base-urlpath": "\"/user/johndoe/\"",
     "hub-host": "",
     "hub-prefix": "/hub/",
     "hub-api-url": "http://172.17.5.167:8081/hub/api",
@@ -126,6 +126,7 @@ def mock_coro_factory(return_value=None, side_effect=None):
         return coro.return_value
 
     coro.called = False
+    coro.call_args = ([], {})
     coro.return_value = return_value
     return coro
 

--- a/remoteappmanager/tests/utils.py
+++ b/remoteappmanager/tests/utils.py
@@ -1,7 +1,6 @@
 import contextlib
 import sys
 import socket
-import functools
 
 import tornado.netutil
 import tornado.testing
@@ -139,21 +138,3 @@ def assert_containers_equal(test_case, actual, expected):
         if getattr(actual, name) != getattr(expected, name):
             message = '{!r} is not identical to the expected {!r}.'
             test_case.fail(message.format(actual, expected))
-
-
-def probe(f):
-    """Wraps a function/method to add a probe we can check after the call.
-    Kind of like mock, but preserves the current behavior."""
-
-    @functools.wraps(f)
-    def _f(*args, **kwargs):
-        _f.called = True
-        _f.call_count += 1
-
-        return f(*args, **kwargs)
-
-    _f.called = False
-    _f.call_count = 0
-
-    return _f
-

--- a/remoteappmanager/webapi/admin/tests/test_accounting.py
+++ b/remoteappmanager/webapi/admin/tests/test_accounting.py
@@ -18,10 +18,10 @@ class TestAccounting(WebAPITestCase):
         return app
 
     def test_delete(self):
-        self.delete("/user/username/api/v1/accounting/mapping_id/",
+        self.delete("/user/johndoe/api/v1/accounting/cbaee2e8ef414f9fb0f1c97416b8aa6c/",  # noqa
                     httpstatus.NO_CONTENT)
 
-        self.delete("/user/username/api/v1/accounting/12345/",
+        self.delete("/user/johndoe/api/v1/accounting/12345/",
                     httpstatus.NOT_FOUND)
 
     def test_unable_to_delete(self):
@@ -29,20 +29,20 @@ class TestAccounting(WebAPITestCase):
                         "dummy.DummyDBAccounting.revoke_access_by_id"
                         ) as mock_delete_user:
             mock_delete_user.side_effect = UnsupportedOperation()
-            self.delete("/user/username/api/v1/accounting/mapping_id/",
+            self.delete("/user/johndoe/api/v1/accounting/cbaee2e8ef414f9fb0f1c97416b8aa6c/",  # noqa
                         httpstatus.INTERNAL_SERVER_ERROR)
 
     def test_create(self):
-        self.post("/user/username/api/v1/accounting/",
+        self.post("/user/johndoe/api/v1/accounting/",
                   {"user_name": ""},
                   httpstatus.BAD_REQUEST)
 
-        self.post("/user/username/api/v1/accounting/",
+        self.post("/user/johndoe/api/v1/accounting/",
                   {},
                   httpstatus.BAD_REQUEST)
 
-        self.post("/user/username/api/v1/accounting/",
-                  {"user_name": "username",
+        self.post("/user/johndoe/api/v1/accounting/",
+                  {"user_name": "johndoe",
                    "image_name": "image_id1",
                    "allow_home": True,
                    "volume": "/foo:/bar:ro"
@@ -50,8 +50,8 @@ class TestAccounting(WebAPITestCase):
                   httpstatus.CREATED)
 
         # Post in this case is idempotent
-        self.post("/user/username/api/v1/accounting/",
-                  {"user_name": "username",
+        self.post("/user/johndoe/api/v1/accounting/",
+                  {"user_name": "johndoe",
                    "image_name": "image_id1",
                    "allow_home": True,
                    "volume": "/foo:/bar:ro"
@@ -63,8 +63,8 @@ class TestAccounting(WebAPITestCase):
                         "dummy.DummyDBAccounting.grant_access"
                         ) as mock_grant_access:
             mock_grant_access.side_effect = UnsupportedOperation()
-            self.post("/user/username/api/v1/accounting/",
-                      {"user_name": "username",
+            self.post("/user/johndoe/api/v1/accounting/",
+                      {"user_name": "johndoe",
                        "image_name": "image_id1",
                        "allow_home": True,
                        "volume": "/foo:/bar:ro"
@@ -74,8 +74,8 @@ class TestAccounting(WebAPITestCase):
     def test_delete_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
 
-        self.delete("/user/username/api/v1/accounting/mapping_id/",
+        self.delete("/user/johndoe/api/v1/accounting/cbaee2e8ef414f9fb0f1c97416b8aa6c/",  # noqa
                     httpstatus.NOT_FOUND)
 
     def cookie_auth_token(self):
-        return "jupyter-hub-token-username=username"
+        return "jupyter-hub-token-johndoe=johndoe"

--- a/remoteappmanager/webapi/admin/tests/test_application.py
+++ b/remoteappmanager/webapi/admin/tests/test_application.py
@@ -18,13 +18,13 @@ class TestApplication(WebAPITestCase):
         return app
 
     def test_delete(self):
-        self.delete("/user/username/api/v1/applications/0/",
+        self.delete("/user/johndoe/api/v1/applications/0/",
                     httpstatus.NO_CONTENT)
 
-        self.delete("/user/username/api/v1/applications/12345/",
+        self.delete("/user/johndoe/api/v1/applications/12345/",
                     httpstatus.NOT_FOUND)
 
-        self.delete("/user/username/api/v1/applications/foo/",
+        self.delete("/user/johndoe/api/v1/applications/foo/",
                     httpstatus.NOT_FOUND)
 
     def test_unable_to_delete(self):
@@ -32,15 +32,15 @@ class TestApplication(WebAPITestCase):
                         "dummy.DummyDBAccounting.remove_application"
                         ) as mock_delete_app:
             mock_delete_app.side_effect = UnsupportedOperation()
-            self.delete("/user/username/api/v1/applications/1/",
+            self.delete("/user/johndoe/api/v1/applications/1/",
                         httpstatus.INTERNAL_SERVER_ERROR)
 
     def test_create(self):
-        self.post("/user/username/api/v1/applications/",
+        self.post("/user/johndoe/api/v1/applications/",
                   {"image_name": "foobar"},
                   httpstatus.CREATED)
 
-        self.post("/user/username/api/v1/applications/",
+        self.post("/user/johndoe/api/v1/applications/",
                   {"image_name": "foobar"},
                   httpstatus.CONFLICT)
 
@@ -49,24 +49,24 @@ class TestApplication(WebAPITestCase):
                         "dummy.DummyDBAccounting.create_application"
                         ) as mock_create_app:
             mock_create_app.side_effect = UnsupportedOperation()
-            self.post("/user/username/api/v1/applications/",
+            self.post("/user/johndoe/api/v1/applications/",
                       {"image_name": "foobar"},
                       httpstatus.INTERNAL_SERVER_ERROR)
 
     def test_create_invalid_representation(self):
-        self.post("/user/username/api/v1/applications/",
+        self.post("/user/johndoe/api/v1/applications/",
                   {"image_name": ""},
                   httpstatus.BAD_REQUEST)
 
-        self.post("/user/username/api/v1/applications/",
+        self.post("/user/johndoe/api/v1/applications/",
                   {},
                   httpstatus.BAD_REQUEST)
 
     def test_delete_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
 
-        self.delete("/user/username/api/v1/applications/0/",
+        self.delete("/user/johndoe/api/v1/applications/0/",
                     httpstatus.NOT_FOUND)
 
     def cookie_auth_token(self):
-        return "jupyter-hub-token-username=username"
+        return "jupyter-hub-token-johndoe=johndoe"

--- a/remoteappmanager/webapi/admin/tests/test_container.py
+++ b/remoteappmanager/webapi/admin/tests/test_container.py
@@ -19,40 +19,40 @@ class TestContainer(WebAPITestCase):
 
     def test_delete(self):
         self._app.container_manager.find_container = mock_coro_factory(
-            DockerContainer(user="username")
+            DockerContainer(user="johndoe")
         )
-        self.delete("/user/username/api/v1/containers/found/",
+        self.delete("/user/johndoe/api/v1/containers/found/",
                     httpstatus.NO_CONTENT)
 
         self.assertTrue(self._app.reverse_proxy.unregister.called)
 
         self._app.container_manager.find_container = \
             mock_coro_factory(return_value=None)
-        self.delete("/user/username/api/v1/containers/notfound/",
+        self.delete("/user/johndoe/api/v1/containers/notfound/",
                     httpstatus.NOT_FOUND)
 
     def test_delete_failure_reverse_proxy(self):
         self._app.container_manager.find_container = mock_coro_factory(
-            DockerContainer(user="username")
+            DockerContainer(user="johndoe")
         )
-        self._app.reverse_proxy.unregister.side_effect = Exception()
+        self._app.reverse_proxy.unregister.side_effect = Exception("BOOM!")
 
-        self.delete("/user/username/api/v1/containers/found/",
+        self.delete("/user/johndoe/api/v1/containers/found/",
                     httpstatus.NO_CONTENT)
 
     def test_delete_failure_stop_container(self):
         manager = self._app.container_manager
         manager.find_container = mock_coro_factory(
-            DockerContainer(user="username")
+            DockerContainer(user="johndoe")
         )
         manager.stop_and_remove_container = mock_coro_factory(
-            side_effect=Exception())
+            side_effect=Exception("BOOM!"))
 
-        self.delete("/user/username/api/v1/containers/found/",
+        self.delete("/user/johndoe/api/v1/containers/found/",
                     httpstatus.NO_CONTENT)
 
     def cookie_auth_token(self):
-        return "jupyter-hub-token-username=username"
+        return "jupyter-hub-token-johndoe=johndoe"
 
 
 class TestContainerNoUser(WebAPITestCase):
@@ -62,8 +62,8 @@ class TestContainerNoUser(WebAPITestCase):
         return app
 
     def test_delete_no_user(self):
-        self.delete("/user/username/api/v1/containers/found/",
+        self.delete("/user/johndoe/api/v1/containers/found/",
                     httpstatus.NOT_FOUND)
 
     def cookie_auth_token(self):
-        return "jupyter-hub-token-username=username"
+        return "jupyter-hub-token-johndoe=johndoe"

--- a/remoteappmanager/webapi/admin/tests/test_user.py
+++ b/remoteappmanager/webapi/admin/tests/test_user.py
@@ -18,13 +18,13 @@ class TestUser(WebAPITestCase):
         return app
 
     def test_delete(self):
-        self.delete("/user/username/api/v1/users/0/",
+        self.delete("/user/johndoe/api/v1/users/0/",
                     httpstatus.NO_CONTENT)
 
-        self.delete("/user/username/api/v1/users/12345/",
+        self.delete("/user/johndoe/api/v1/users/12345/",
                     httpstatus.NOT_FOUND)
 
-        self.delete("/user/username/api/v1/users/foo/",
+        self.delete("/user/johndoe/api/v1/users/foo/",
                     httpstatus.NOT_FOUND)
 
     def test_unable_to_delete(self):
@@ -32,23 +32,23 @@ class TestUser(WebAPITestCase):
                         "dummy.DummyDBAccounting.remove_user"
                         ) as mock_delete_user:
             mock_delete_user.side_effect = UnsupportedOperation()
-            self.delete("/user/username/api/v1/users/1/",
+            self.delete("/user/johndoe/api/v1/users/1/",
                         httpstatus.INTERNAL_SERVER_ERROR)
 
     def test_create(self):
-        self.post("/user/username/api/v1/users/",
+        self.post("/user/johndoe/api/v1/users/",
                   {"name": ""},
                   httpstatus.BAD_REQUEST)
 
-        self.post("/user/username/api/v1/users/",
+        self.post("/user/johndoe/api/v1/users/",
                   {},
                   httpstatus.BAD_REQUEST)
 
-        self.post("/user/username/api/v1/users/",
+        self.post("/user/johndoe/api/v1/users/",
                   {"name": "foobar"},
                   httpstatus.CREATED)
 
-        self.post("/user/username/api/v1/users/",
+        self.post("/user/johndoe/api/v1/users/",
                   {"name": "foobar"},
                   httpstatus.CONFLICT)
 
@@ -57,15 +57,15 @@ class TestUser(WebAPITestCase):
                         "dummy.DummyDBAccounting.create_user"
                         ) as mock_create_user:
             mock_create_user.side_effect = UnsupportedOperation()
-            self.post("/user/username/api/v1/users/",
+            self.post("/user/johndoe/api/v1/users/",
                       {"name": "foobar"},
                       httpstatus.INTERNAL_SERVER_ERROR)
 
     def test_delete_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
 
-        self.delete("/user/username/api/v1/users/0/",
+        self.delete("/user/johndoe/api/v1/users/0/",
                     httpstatus.NOT_FOUND)
 
     def cookie_auth_token(self):
-        return "jupyter-hub-token-username=username"
+        return "jupyter-hub-token-johndoe=johndoe"

--- a/remoteappmanager/webapi/container.py
+++ b/remoteappmanager/webapi/container.py
@@ -260,7 +260,7 @@ class Container(Resource):
             e.reason = 'timeout'
             raise e
         except Exception as e:
-            self.log.error(
+            self.log.exception(
                 "Unhandled error starting {user}'s "
                 "container: {error}".format(user=user_name, error=e)
             )

--- a/remoteappmanager/webapi/tests/test_container.py
+++ b/remoteappmanager/webapi/tests/test_container.py
@@ -29,7 +29,7 @@ class TestContainer(WebAPITestCase):
             [DockerContainer()])
 
         code, data = self.get(
-            "/user/username/api/v1/containers/",
+            "/user/johndoe/api/v1/containers/",
             httpstatus.OK)
 
         self.assertEqual(data, {"items": ["", ""]})
@@ -46,9 +46,9 @@ class TestContainer(WebAPITestCase):
                 url_id="3456"
             ))
             self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                     configurables={
                         "resolution": {
                             "resolution": "1024x768"
@@ -69,9 +69,9 @@ class TestContainer(WebAPITestCase):
             self._app.container_manager.stop_and_remove_container = \
                 mock_coro_factory()
             _, data = self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                     configurables={
                         "resolution": {
                             "resolution": "1024x768"
@@ -100,9 +100,9 @@ class TestContainer(WebAPITestCase):
                 side_effect=Exception("Boom!"))
 
             _, data = self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                     configurables={
                         "resolution": {
                             "resolution": "1024x768"
@@ -130,9 +130,9 @@ class TestContainer(WebAPITestCase):
                 side_effect=Exception("Boom!"))
 
             _, data = self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                     configurables={
                         "resolution": {
                             "resolution": "1024x768"
@@ -147,9 +147,9 @@ class TestContainer(WebAPITestCase):
 
     def test_create_fails_for_incorrect_configurable(self):
         self.post(
-            "/user/username/api/v1/containers/",
+            "/user/johndoe/api/v1/containers/",
             dict(
-                mapping_id="mapping_id",
+                mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                 configurables={
                     "resolution": {
                         "wooo": "dsdsa"
@@ -167,9 +167,9 @@ class TestContainer(WebAPITestCase):
                    new_callable=mock_coro_new_callable()):
 
             self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                     configurables={
                         "resolution": {
                         }
@@ -179,9 +179,9 @@ class TestContainer(WebAPITestCase):
             )
 
             self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                     configurables={
                     }
                 ),
@@ -189,16 +189,16 @@ class TestContainer(WebAPITestCase):
             )
 
             self.post(
-                "/user/username/api/v1/containers/",
+                "/user/johndoe/api/v1/containers/",
                 dict(
-                    mapping_id="mapping_id",
+                    mapping_id="cbaee2e8ef414f9fb0f1c97416b8aa6c",
                 ),
                 httpstatus.CREATED
             )
 
     def test_create_fails_for_missing_mapping_id(self):
         _, data = self.post(
-            "/user/username/api/v1/containers/",
+            "/user/johndoe/api/v1/containers/",
             dict(
                 whatever="123"
             ),
@@ -211,7 +211,7 @@ class TestContainer(WebAPITestCase):
 
     def test_create_fails_for_invalid_mapping_id(self):
         _, data = self.post(
-            "/user/username/api/v1/containers/",
+            "/user/johndoe/api/v1/containers/",
             dict(mapping_id="whatever"),
             httpstatus.BAD_REQUEST
         )
@@ -222,9 +222,9 @@ class TestContainer(WebAPITestCase):
 
     def test_retrieve(self):
         self._app.container_manager.find_container = mock_coro_factory(
-            DockerContainer(user="username")
+            DockerContainer(user="johndoe")
         )
-        _, data = self.get("/user/username/api/v1/containers/found/",
+        _, data = self.get("/user/johndoe/api/v1/containers/found/",
                            httpstatus.OK)
 
         self.assertEqual(data["image_name"], "")
@@ -232,40 +232,40 @@ class TestContainer(WebAPITestCase):
 
         self._app.container_manager.find_container = \
             mock_coro_factory(return_value=None)
-        self.get("/user/username/api/v1/containers/notfound/",
+        self.get("/user/johndoe/api/v1/containers/notfound/",
                  httpstatus.NOT_FOUND)
 
     def test_prevent_retrieve_from_other_user(self):
         self._app.container_manager.find_container = mock_coro_factory(None)
 
-        self.get("/user/username/api/v1/containers/found/",
+        self.get("/user/johndoe/api/v1/containers/found/",
                  httpstatus.NOT_FOUND)
         kwargs = self._app.container_manager.find_container.call_args[1]
-        self.assertEqual(kwargs["user_name"], "username")
+        self.assertEqual(kwargs["user_name"], "johndoe")
 
     def test_delete(self):
         self._app.container_manager.find_container = mock_coro_factory(
-            DockerContainer(user="username")
+            DockerContainer(user="johndoe")
         )
 
-        self.delete("/user/username/api/v1/containers/found/",
+        self.delete("/user/johndoe/api/v1/containers/found/",
                     httpstatus.NO_CONTENT)
         self.assertTrue(self._app.reverse_proxy.unregister.called)
 
         self._app.container_manager.find_container = \
             mock_coro_factory(return_value=None)
-        self.delete("/user/username/api/v1/containers/notfound/",
+        self.delete("/user/johndoe/api/v1/containers/notfound/",
                     httpstatus.NOT_FOUND)
 
     def test_prevent_delete_from_other_user(self):
         self._app.container_manager.find_container = mock_coro_factory(
             None
         )
-        self.delete("/user/username/api/v1/containers/found/",
+        self.delete("/user/johndoe/api/v1/containers/found/",
                     httpstatus.NOT_FOUND)
 
         kwargs = self._app.container_manager.find_container.call_args[1]
-        self.assertEqual(kwargs["user_name"], "username")
+        self.assertEqual(kwargs["user_name"], "johndoe")
 
     def test_post_start(self):
         with patch("remoteappmanager"
@@ -277,9 +277,9 @@ class TestContainer(WebAPITestCase):
                 mock_coro_factory(return_value=[DockerContainer()])
 
             self.assertFalse(self._app.reverse_proxy.register.called)
-            self.post("/user/username/api/v1/containers/",
+            self.post("/user/johndoe/api/v1/containers/",
                       {
-                          "mapping_id": "mapping_id",
+                          "mapping_id": "cbaee2e8ef414f9fb0f1c97416b8aa6c",
                           "configurables": {
                                "resolution": {
                                    "resolution": "1024x768"
@@ -292,12 +292,12 @@ class TestContainer(WebAPITestCase):
     def test_post_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
 
-        self.post("/user/username/api/v1/containers/",
-                  {"mapping_id": "12345"},
+        self.post("/user/johndoe/api/v1/containers/",
+                  {"mapping_id": "b7ca425a51bf40acbd305b3f782714b6"},
                   httpstatus.NOT_FOUND)
 
     def cookie_auth_token(self):
-        return "jupyter-hub-token-username=username"
+        return "jupyter-hub-token-johndoe=johndoe"
 
 
 class TestContainerNoUser(WebAPITestCase):


### PR DESCRIPTION
Refactoring of the Virtual Docker to make it more extensible.
Introduced the VirtualDockerClient to behave like a normal dockerpy client.
Disambiguated many confusing names, and followed a more consistent approach to ids.