### PR TITLE
Pinning against specific version of Jupyterhub to fix red.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests==2.10.0
 docker-py==1.8
 escapism==0.0.1
 jinja2==2.8
-git+git://github.com/jupyterhub/jupyterhub.git@master#egg=jupyterhub
+git+git://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5


### PR DESCRIPTION
Apparently something has changed upstream in jupyterhub so that it makes our master red.
I pinned against 2d1a45f0190059ef436c2f97dc8d6e391eb2d139 for now, but the problem needs to be investigated further.
