### PR TITLE
Remove side effects in tests

### DIFF
--- a/frontend/tests/tests/test_analytics.js
+++ b/frontend/tests/tests/test_analytics.js
@@ -1,10 +1,5 @@
 var gamodule = require("gamodule");
 
-window.apidata = {
-  base_url: "/",
-  prefix: "/"
-};
-
 QUnit.module("Google Analytics");
 QUnit.test("test without analytics", function (assert) {
   var result=[];

--- a/frontend/tests/tests/user/mock_jsapi.js
+++ b/frontend/tests/tests/user/mock_jsapi.js
@@ -33,6 +33,9 @@ module.exports = {
             volume_mode: ""
           },
           configurables: []
+        },
+        container: {
+          url_id: "654321"
         }
       }
     },

--- a/frontend/tests/tests/user/test_application_view.js
+++ b/frontend/tests/tests/user/test_application_view.js
@@ -46,21 +46,20 @@ QUnit.test("rendering iframe", function (assert) {
   }).$mount();
 
   model.update().done(function() {
-    // Simulate application running
-    model.appList[0].status = 'RUNNING';
-    model.appList[0].appData.container = {};
-    model.appList[0].appData.container.url_id = 'https://127.0.0.1:1234/';
+    // Switch to a running application
+    model.selectedIndex = 1;
 
     Vue.nextTick(function() {
       assert.equal(appView.$el.children[0].tagName, 'IFRAME');
+      assert.equal(appView.$el.children[0].getAttribute('src'), '/user/lambda/containers/654321/');
 
       // Render form again by selecting the other application which is stopped
-      model.selectedIndex = 1;
+      model.selectedIndex = 0;
 
       Vue.nextTick(function() {
         assert.equal(
           appView.$el.querySelector('.box-title').innerHTML,
-          model.appList[1].appData.image.ui_name
+          model.appList[0].appData.image.ui_name
         );
 
         done();

--- a/frontend/tests/testsuite.js
+++ b/frontend/tests/testsuite.js
@@ -1,3 +1,8 @@
+window.apidata = {
+  base_url: "/user/lambda",
+  prefix: "/"
+};
+
 require("./tests/user/test_configurables.js");
 require("./tests/user/test_models.js");
 require("./tests/user/test_application_list_view.js");


### PR DESCRIPTION
There was a first side effect with mock_jsapi, it is used by almost all the tests but one test of the application view was changing it.
The second side effect was with the global object `window`, it was changed in the google analytics test.

Closes #470