### PR TITLE
Skip containers that are not found while checking container.items

### DIFF
--- a/remoteappmanager/webapi/container.py
+++ b/remoteappmanager/webapi/container.py
@@ -163,6 +163,9 @@ class ContainerHandler(ResourceHandler):
                 user_name=self.current_user.name,
                 mapping_id=accounting.id)
 
+            if container is None:
+                continue
+
             rest_container = Container(identifier=container.url_id)
             rest_container.fill(container)
             running_containers.append(rest_container)

--- a/remoteappmanager/webapi/tests/test_container.py
+++ b/remoteappmanager/webapi/tests/test_container.py
@@ -25,8 +25,7 @@ class TestContainer(WebAPITestCase):
     def test_items(self):
         manager = self._app.container_manager
         manager.image = mock_coro_factory(Image())
-        manager.find_containers = mock_coro_factory(
-            [
+        manager.find_containers = mock_coro_factory([
                 DockerContainer(user="johndoe",
                                 mapping_id="whatever",
                                 url_id="12345",
@@ -48,12 +47,34 @@ class TestContainer(WebAPITestCase):
              'total': 2,
              'offset': 0,
              'items': {
-                '12345': {
-                    'image_name': 'image',
-                    'name': 'container',
-                    'mapping_id': 'whatever'
-                }
-            }})
+                 '12345': {
+                     'image_name': 'image',
+                     'name': 'container',
+                     'mapping_id': 'whatever'
+                 }
+             }})
+
+    def test_items_with_none_container(self):
+        manager = self._app.container_manager
+        manager.image = mock_coro_factory(Image())
+        manager.find_container = mock_coro_factory(None)
+
+        code, data = self.get("/user/johndoe/api/v1/containers/",
+                              httpstatus.OK)
+
+        # We get two because we have two mapping ids, hence the find_containers
+        # gets called once per each mapping id.
+        # This is a kind of unusual case, because we only get one item
+        # in the items list, due to the nature of the test.
+        self.assertEqual(
+            data,
+            {
+                'identifiers': [],
+                'total': 0,
+                'offset': 0,
+                'items': {}
+            }
+        )
 
     def test_create(self):
         with patch("remoteappmanager"

--- a/remoteappmanager/webapi/tests/test_container.py
+++ b/remoteappmanager/webapi/tests/test_container.py
@@ -62,10 +62,6 @@ class TestContainer(WebAPITestCase):
         code, data = self.get("/user/johndoe/api/v1/containers/",
                               httpstatus.OK)
 
-        # We get two because we have two mapping ids, hence the find_containers
-        # gets called once per each mapping id.
-        # This is a kind of unusual case, because we only get one item
-        # in the items list, due to the nature of the test.
         self.assertEqual(
             data,
             {


### PR DESCRIPTION
The current webapi checks the accounting and fetches containers for the accounting data, but there was nothing to prevent operating on containers not active.
