### PR TITLE
Better feedback to user when starting and stopping application

### DIFF
--- a/frontend/user/vue-components/ApplicationView.vue
+++ b/frontend/user/vue-components/ApplicationView.vue
@@ -51,8 +51,8 @@
           <div class="box-footer">
             <button class="btn btn-primary pull-right start-button"
             @click="startApplication()"
-            :disabled="currentApp.isStarting()">
-              Start
+            :disabled="currentApp.isStarting() || currentApp.isStopping()">
+              {{ {STOPPED: 'Start', STARTING: 'Starting', STOPPING: 'Stopping'}[currentApp.status] }}
             </button>
           </div>
         </div>
@@ -132,6 +132,10 @@
 <style scoped>
   .no-padding {
     padding: 0px;
+  }
+
+  .start-button {
+    min-width: 80px;
   }
 
   #application {


### PR DESCRIPTION
Now it's written "Starting" on the disabled start button when the application is starting, and "Stopping" when the application is stopping.
This button was not disabled when stopping the application, now it is.

Workaround #477 