### PR TITLE
Handle readthedocs inability to run npm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,9 @@ else:
 
 class install(_install):
     def run(self):
-        import subprocess
-        subprocess.check_call(['npm', 'run', 'build'])
+        if not on_rtd:
+            import subprocess
+            subprocess.check_call(['npm', 'run', 'build'])
         super().run()
 
 


### PR DESCRIPTION
Readthedocs does not have npm, so we can't run the full install there.