### PR TITLE
Use astor master to see if we fix the python3.5 compat

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,3 @@
 sphinx==1.4.4
-astor==0.5
+git+https://github.com/berkerpeksag/astor.git#egg=astor
 git+https://github.com/simphony/traitlet-documenter.git@v0.1.0#egg=traitlet_documenter

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools.command.install import install as _install
 VERSION = '1.2.0.dev0'
 
 # Read description
-
 with open('README.rst', 'r') as readme:
     README_TEXT = readme.read()
 


### PR DESCRIPTION
Python 3.5 generates an error in astor 0.5. We replace it with master and see if it works.