### PR TITLE
Fix typo in alembic config file

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -29,7 +29,7 @@ script_location = alembic/
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite://jupyterhub/remoteappmanager.db
+sqlalchemy.url = sqlite:///jupyterhub/remoteappmanager.db
 
 
 # Logging configuration


### PR DESCRIPTION
Minor typo. We were missing a single slash