### PR TITLE
Disable share link when it's a web application

### DIFF
--- a/frontend/user/vue-components/ApplicationLabel.vue
+++ b/frontend/user/vue-components/ApplicationLabel.vue
@@ -16,7 +16,7 @@
             <li>
               <a href="#"
               id="share-button"
-              :class="{ 'disabled-entry': !currentApp.isRunning() }"
+              :class="{ 'disabled-entry': !currentApp.isRunning() || currentApp.appData.image.type == 'webapp' }"
               @click="shareDialog.visible = true">
                 <i class="fa fa-clipboard text-light-blue"></i>
                 Share session

--- a/frontend/user/vue-components/ApplicationView.vue
+++ b/frontend/user/vue-components/ApplicationView.vue
@@ -12,6 +12,9 @@
             <div class="box-tools pull-right"></div>
           </div>
           <div class="box-body">
+            <h4>Type</h4>
+            <span>{{ currentApp.appData.image.type == "webapp" ? "Web": "VNC" }} application</span>
+
             <h4>Description</h4>
             <span id="app-description">{{ currentApp.appData.image.description }}</span>
 

--- a/remoteappmanager/webapi/application.py
+++ b/remoteappmanager/webapi/application.py
@@ -26,6 +26,7 @@ class Image(ResourceFragment):
     ui_name = Unicode()
     icon_128 = Unicode()
     description = Unicode()
+    type = Unicode()
     policy = OneOf(Policy)
     configurables = List(Unicode)
 
@@ -71,11 +72,12 @@ class ApplicationHandler(ResourceHandler):
         resource.mapping_id = identifier
         resource.image = Image()
         resource.image.fill({
-                "name": image.name,
-                "ui_name": image.ui_name,
-                "icon_128": image.icon_128,
-                "description": image.description,
-                "configurables": [conf.tag for conf in image.configurables]
+            "name": image.name,
+            "ui_name": image.ui_name,
+            "icon_128": image.icon_128,
+            "description": image.description,
+            "type": image.type,
+            "configurables": [conf.tag for conf in image.configurables]
         })
         resource.image.policy = Policy()
         resource.image.policy.fill(policy)

--- a/remoteappmanager/webapi/tests/test_application.py
+++ b/remoteappmanager/webapi/tests/test_application.py
@@ -79,6 +79,7 @@ class TestApplication(WebAPITestCase):
                         },
                         'name': 'boo',
                         'icon_128': '',
+                        'type': '',
                         'ui_name': 'foo_ui',
                         'description': '',
                         'configurables': []
@@ -94,6 +95,7 @@ class TestApplication(WebAPITestCase):
                             'volume_target': 'bar'
                         },
                         'name': 'boo',
+                        'type': '',
                         'icon_128': '',
                         'ui_name': 'foo_ui',
                         'description': '',
@@ -128,17 +130,18 @@ class TestApplication(WebAPITestCase):
                          {
                              'mapping_id': "one",
                              'image': {
-                              'configurables': [],
-                              'description': '',
-                              'icon_128': '',
-                              'name': 'boo',
-                              'policy': {
-                                    "allow_home": True,
-                                    "volume_mode": 'ro',
-                                    "volume_source": "foo",
-                                    "volume_target": "bar",
-                              },
-                              'ui_name': 'foo_ui'}})
+                                 'configurables': [],
+                                 'description': '',
+                                 'type': '',
+                                 'icon_128': '',
+                                 'name': 'boo',
+                                 'policy': {
+                                     "allow_home": True,
+                                     "volume_mode": 'ro',
+                                     "volume_source": "foo",
+                                     "volume_target": "bar",
+                                 },
+                                 'ui_name': 'foo_ui'}})
 
         self._app.container_manager.find_containers = \
             mock_coro_factory(return_value=[Container(
@@ -159,6 +162,7 @@ class TestApplication(WebAPITestCase):
                              'image': {
                                  'description': '',
                                  'icon_128': '',
+                                 'type': '',
                                  'name': 'boo',
                                  'ui_name': 'foo_ui',
                                  'policy': {


### PR DESCRIPTION
As it's difficult to share the view of a web application, we disable the share link for those kind of applications.
I also added an information to the user about the type of the application.

Closes  #514 