### PR TITLE
Fix issue with hard coded user name

### DIFF
--- a/frontend/admin/admin-resources.js
+++ b/frontend/admin/admin-resources.js
@@ -29,7 +29,7 @@ var API = (function () {
   // Object representing the interface to the Web API.
   // @param base_url : the url at which to find the web API endpoint.
   var self = {};
-  self.base_urlpath = "/user/admin/";
+  self.base_urlpath = window.apidata.base_url;
   self.default_options = {
     contentType: "application/json",
     cache: false,

--- a/frontend/user/user-resources.js
+++ b/frontend/user/user-resources.js
@@ -29,7 +29,7 @@ var API = (function () {
   // Object representing the interface to the Web API.
   // @param base_url : the url at which to find the web API endpoint.
   var self = {};
-  self.base_urlpath = "/user/test/";
+  self.base_urlpath = window.apidata.base_url;
   self.default_options = {
     contentType: "application/json",
     cache: false,


### PR DESCRIPTION
When copying files originally generated by the backend on the frontend, I didn't check the code. It turns out that the base_url was finally hard coded and no other user than "admin" and "test" could have access to data from the backend.

Closes #533