### PR TITLE
Extract global action from datatable

### DIFF
--- a/frontend/admin/vue-components/AccountingView.vue
+++ b/frontend/admin/vue-components/AccountingView.vue
@@ -1,5 +1,7 @@
 <template>
   <adminlte-box :title="'Accounting for user ' + $route.params.id">
+    <button slot="tools" class="btn btn-primary" @click="newAccountingDialog.visible = true">Create New Policy</button>
+
     <div class="alert alert-danger" v-if="communicationError">
       <strong>Error:</strong> {{communicationError}}
     </div>
@@ -7,7 +9,6 @@
     <data-table
     :headers.once="table.headers"
     :rows="table.rows"
-    :globalActions="table.globalActions"
     :rowActions="table.rowActions">
     </data-table>
 
@@ -47,10 +48,6 @@
             "ID", "Image", "Workspace", "Vol. source", "Vol. target", "Readonly"
           ],
           rows: [],
-          globalActions: [{
-            label: "Create New Entry",
-            callback: () => {this.newAccountingDialog.visible = true;}
-          }],
           rowActions: [{
             label: "Remove",
             callback: this.removeAction

--- a/frontend/admin/vue-components/ApplicationsView.vue
+++ b/frontend/admin/vue-components/ApplicationsView.vue
@@ -1,5 +1,7 @@
 <template>
   <adminlte-box title="Applications">
+    <button slot="tools" class="btn btn-primary" @click="newApplicationDialog.visible = true">Add New Application</button>
+
     <div class="alert alert-danger" v-if="communicationError">
       <strong>Error:</strong> {{communicationError}}
     </div>
@@ -7,7 +9,6 @@
     <data-table
     :headers.once="table.headers"
     :rows="table.rows"
-    :globalActions="table.globalActions"
     :rowActions="table.rowActions">
     </data-table>
 
@@ -43,10 +44,6 @@
         table: {
           headers: ["ID", "Image"],
           rows: [],
-          globalActions: [{
-            label: "Create New Entry",
-            callback: () => {this.newApplicationDialog.visible = true;}
-          }],
           rowActions: [{
             label: "Remove",
             callback: this.removeAction

--- a/frontend/admin/vue-components/ContainersView.vue
+++ b/frontend/admin/vue-components/ContainersView.vue
@@ -6,7 +6,6 @@
     <data-table
     :headers.once="table.headers"
     :rows="table.rows"
-    :globalActions="table.globalActions"
     :rowActions="table.rowActions">
     </data-table>
     <confirm-dialog

--- a/frontend/admin/vue-components/UsersView.vue
+++ b/frontend/admin/vue-components/UsersView.vue
@@ -1,5 +1,7 @@
 <template>
   <adminlte-box title="Users">
+    <button slot="tools" class="btn btn-primary" @click="newUserDialog.visible = true">Create New User</button>
+
     <div class="alert alert-danger" v-if="communicationError">
       <strong>Error:</strong> {{communicationError}}
     </div>
@@ -7,7 +9,6 @@
     <data-table
     :headers.once="table.headers"
     :rows="table.rows"
-    :globalActions="table.globalActions"
     :rowActions="table.rowActions">
     </data-table>
     <new-user-dialog
@@ -39,10 +40,6 @@
         table: {
           headers: ["ID", "Username"],
           rows: [],
-          globalActions: [{
-            label: "Create New Entry",
-            callback: () => {this.newUserDialog.visible = true;}
-          }],
           rowActions: [{
             label: "Policies",
             callback: this.showPolicyAction,

--- a/frontend/toolkit/DataTable.vue
+++ b/frontend/toolkit/DataTable.vue
@@ -1,32 +1,27 @@
 <template>
-  <div class="column-container">
-    <div class="align-right">
-      <button v-for="action in globalActions" class="btn btn-primary" @click="action.callback">{{action.label}}</button>
-    </div>
-    <div class="table-responsive">
-      <table class="table table-hover no-margin">
-        <thead>
-          <tr>
-            <th v-for="header in headers">{{header}}</th>
-            <th v-if="rowActions.length > 0">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(row, row_index) in rows">
-            <template v-for="(value, col_index) in row">
-              <td v-if="isBoolean(value)"><i class="fa fa-check" v-if="value"></i></td>
-              <td v-else>{{value}}</td>
-            </template>
-            <td>
-              <button v-for="action in rowActions"
-              :class="buttonClassFromType(action.type)"
-              style="margin-right: 10px"
-              @click="action.callback(row)">{{action.label}}</button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+  <div class="table-responsive">
+    <table class="table table-hover no-margin">
+      <thead>
+        <tr>
+          <th v-for="header in headers">{{header}}</th>
+          <th v-if="rowActions.length > 0">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(row, row_index) in rows">
+          <template v-for="(value, col_index) in row">
+            <td v-if="isBoolean(value)"><i class="fa fa-check" v-if="value"></i></td>
+            <td v-else>{{value}}</td>
+          </template>
+          <td>
+            <button v-for="action in rowActions"
+            :class="buttonClassFromType(action.type)"
+            style="margin-right: 10px"
+            @click="action.callback(row)">{{action.label}}</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>
 


### PR DESCRIPTION
The datatable component should only take care of rendering the datatable. As buttons for global actions are not part of the datatable itself, I think it's better to render them from the components which render the datatable.
Furthermore, it allows us to render those buttons inside the `box-tools` element provided by AdminLTE, which is the proper place for those buttons.