### PR TITLE
Report fails due to invalid image name

### DIFF
--- a/frontend/admin/vue-components/accounting/NewAccountingDialog.vue
+++ b/frontend/admin/vue-components/accounting/NewAccountingDialog.vue
@@ -136,8 +136,12 @@
         .done(() => {
           this.$emit('created');
         })
-        .fail(() => {
-          this.communicationError = "The request could not be executed successfully";
+        .fail((error) => {
+          if(error.code == 404) {
+            this.communicationError = "The requested image is not available";
+          } else {
+            this.communicationError = "The request could not be executed successfully";
+          }
         });
       },
 


### PR DESCRIPTION
I assume here that if it's a 404 error then it's because the image was not found.

Closes #507