### PR TITLE
FEAT: Update Simphony-Remote repo with latest development (2.2.0.dev)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist/
 jupyterhub/remoteappmanager.db
 jupyterhub/test.key.org
 remoteappmanager/version.py
+
+# PyCharm
+*.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 
 python:
-    - 3.4
+    - 3.6
 
 sudo: required
-dist: trusty
+dist: bionic
 addons:
-    firefox: "45.0"
+    firefox: "75.0"
 
 before_install:
     - firefox --version

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ devdeps:
 	wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
 	sudo sh -c 'tar -x geckodriver -zf geckodriver-v0.26.0-linux64.tar.gz -O > /usr/bin/geckodriver'
 	sudo chmod +x /usr/bin/geckodriver
-	rm geckodriver-v0.23.0-linux64.tar.gz
+	rm geckodriver-v0.26.0-linux64.tar.gz
 
 .PHONY: develop
 develop:

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ devdeps:
 	pip3 -q install -r dev-requirements.txt -r doc-requirements.txt
 	sudo apt-get -qq install phantomjs
 
+	# Install geckodriver (for selenium testing)
+	wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
+	sudo sh -c 'tar -x geckodriver -zf geckodriver-v0.26.0-linux64.tar.gz -O > /usr/bin/geckodriver'
+	sudo chmod +x /usr/bin/geckodriver
+	rm geckodriver-v0.23.0-linux64.tar.gz
+
 .PHONY: develop
 develop:
 	@echo "Installing application"

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ test: pythontest jstest
 pythontest:
 	@echo "Running python testsuite"
 	@echo "------------------------"
-	python -m tornado.testing tornado.test.web_test -s remoteappmanager -t .
+	python -m tornado.testing discover -s remoteappmanager -t .
 
 .PHONY: jstest
 jstest:

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ test: pythontest jstest
 pythontest:
 	@echo "Running python testsuite"
 	@echo "------------------------"
-	python -m tornado.testing tornado.test.web_test discover -s remoteappmanager -t .
+	python -m tornado.testing tornado.test.web_test -s remoteappmanager -t .
 
 .PHONY: jstest
 jstest:

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ dockerdeps:
 npmdeps:
 
 	if [[ `command -v npm` == '' ]]; then \
+		sudo $(PKG_MNGR) install -y node-gyp libssl1.0-dev; \
 		sudo $(PKG_MNGR) install -y npm; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ test: pythontest jstest
 pythontest:
 	@echo "Running python testsuite"
 	@echo "------------------------"
-	python -m tornado.testing discover -s remoteappmanager -t .
+	python -m tornado.testing tornado.test.web_test discover -s remoteappmanager -t .
 
 .PHONY: jstest
 jstest:

--- a/README.rst
+++ b/README.rst
@@ -190,3 +190,5 @@ within the docker container.
 
 Log out of SimphonyRemote (red 'admin' button in the top right) and log in using the username you specified for your
 new user and no password, you should now be able to start your application!
+
+# One line change

--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,6 @@ Basic instructions for a single-user deployment on a local (or virtual) machine 
 A more comprehensive deployment documentation, including use of a ``nginx`` reverse proxy and
 running as a service can be found `here <doc/source/deployment.rst>`_
 
-If you would like
-to test a deployment of S-R using Docker for CI purposes, then please use the following
-`instructions <ci/ci_instructions.rst>`_.
-
 Single Machine
 --------------
 

--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,6 @@ image from a docker registry, or creating our own locally.
 To create new images, please follow the documentation hosted at Horizon 2020
 `Simphony <https://github.com/simphony/simphony-remote-docker>`_ project repository.
 
-.. _deploy_setup_db:
 
 Setup Database Accounting
 -------------------------

--- a/README.rst
+++ b/README.rst
@@ -190,5 +190,3 @@ within the docker container.
 
 Log out of SimphonyRemote (red 'admin' button in the top right) and log in using the username you specified for your
 new user and no password, you should now be able to start your application!
-
-# One line change

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,6 @@ Key provided features:
    - Sharing of working sessions.
    - Based on community supported open source initiatives (JupyterHub)
 
-
 Acknowledgments
 ---------------
 
@@ -22,3 +21,177 @@ This software is developed under the SimPhoNy project, an EU-project
 funded by the 7th Framework Programme (Project number 604005) under
 the call NMP.2013.1.4-1: "Development of an integrated multi-scale
 modelling environment for nanomaterials and systems by design".
+
+Documentation
+=============
+
+A quick setup guide is given below; please see the `documentation <doc/source/index.rst>`_ for more
+detailed information.
+
+Deployment (Quick Start)
+========================
+
+Basic instructions for a single-user deployment on a local (or virtual) machine are provided below.
+A more comprehensive deployment documentation, including use of a ``nginx`` reverse proxy and
+running as a service can be found `here <doc/source/deployment.rst>`_
+
+If you would like
+to test a deployment of S-R using Docker for CI purposes, then please use the following
+`instructions <ci/ci_instructions.rst>`_.
+
+Single Machine
+--------------
+
+If you would like to test a deployment of S-R using Docker for CI purposes, then please use the following
+`instructions <doc/source/developer/ci_instructions.rst>`_.
+
+.. note::
+
+   The following instructions assume a clean up-to-date Ubuntu 18.04 or CentOS 7
+   system with ``git`` and ``make`` installed.
+
+#. Retrieve the required repository::
+
+     git clone https://github.com/simphony/simphony-remote.git
+
+#. Make sure that you have a recent version of Docker. This guide has been tested on version 19.03.5 (build 633a0ea838).
+   :code:`make deps` will install the latest version if you do not already have a version of docker available.
+   Full instructions available at `the Docker website <https://docs.docker.com/engine/installation/linux/ubuntulinux/>`_.
+   A Makefile rule is provided for convenience.
+   **NOTE: this overwrites the docker.list file you might have setup in your /etc/apt/sources.d/ directory**.
+   You might be prompted for the root password to execute this::
+
+     make deps
+
+#. Make sure your docker server is running, and your user is allowed to connect to
+   the docker server (check accessibility of ``/var/run/docker.sock``). You obtain this by
+   running::
+
+     sudo service docker start
+
+   followed by either::
+
+    (Ubuntu) sudo addgroup your_username docker
+    (CentOS) sudo groupmod -aG docker your_username
+
+   and logging out and in again. Check if your docker server is operative by running::
+
+     docker info
+
+#. Create and activate a virtual environment, then set the appropriate PATH for the node modules::
+
+     make venv
+     . venv/bin/activate
+     export PATH=`npm bin`:$PATH
+
+#. Install the python dependencies::
+
+     make pythondeps
+
+#. And install the package itself::
+
+     make install
+
+#. Generate the SSL certificates if you do not already have them. The
+   resulting certificates will have names test.* because they are
+   self-signed and **are not supposed to be used for production**.
+   A CA-signed certificate should be obtained instead.
+   The certificates will be created in the jupyterhub directory::
+
+     make certs
+
+#. Create the database. By default, this is a sqlite file::
+
+     make db
+
+#. If you are using virtual users (users that are not present on the system) you need to create
+   a temporary space where the virtual user homes are created::
+
+     mkdir /tmp/remoteapp
+
+The installation is complete, you can now start the service.
+
+Start JupyterHub
+----------------
+
+#. Change dir into ``jupyterhub/``::
+
+     cd ./jupyterhub
+
+#. Verify that ``jupyterhub_config.py`` is correct for your deployment
+   machine setup (see `configuration <doc/source/configuration>`_ for more details).
+   Some example configuration files are provided in the
+   ``example_configurations/`` directory.
+
+#. Start JupyterHub by invoking the start script::
+
+     bash start.sh
+
+   .. note::
+      If you want to keep the application running, use screen to start
+      a detachable terminal.
+
+   .. note::
+      Running on OSX or with a separate docker machine requires that the
+      appropriate environment variables are set before starting jupyterhub.
+      refer to the command ``docker-machine env`` to setup the appropriate
+      environment. In general, invoking::
+
+            eval `docker-machine env`
+
+      will enable the appropriate environment.
+      On Linux, by default the host machine and the docker machine coincide,
+      so this step is not needed.
+
+#. JupyterHub is now running at https://127.0.0.1:8000
+
+   For many browsers this must be typed exactly as shown - using http://127.0.0.1:8000 or localhost:8000
+   will not work. As mentioned above, the self-signed SSL certificates should cause your browser to
+   raise a warning and require adding 127.0.0.1 to the list of security exceptions.
+
+   Currently, the only fully supported browser is Google Chrome/Chromium. The latest version of Firefox has shown
+   some issues with keyboard input when the vnc is running, however for the most part users will likley not
+   suffer any issues.
+
+Setting up Docker images
+------------------------
+
+Next, we need to obtain a docker image to run on Simphony-Remote. This can be done by either pulling an existing
+image from a docker registry, or creating our own locally.
+
+To create new images, please follow the documentation hosted at Horizon 2020
+`Simphony <https://github.com/simphony/simphony-remote-docker>`_ project repository.
+
+.. _deploy_setup_db:
+
+Setup Database Accounting
+-------------------------
+
+A database is needed for managing the remote applications available for each user.
+Note that this database is in addition to the database created or used by JupyterHub.
+
+Default sqlite database
+
+   **remoteappmanager** by default uses a sqlite database *remoteappmanager.db* in
+   the current work directory.  The **remoteappdb** command-line tool is provided
+   for setting up the database.  Please refer to the `utilities <doc/source/utilities.rst>`_
+   section for details on the use of this program.
+
+
+Setting up Users
+----------------
+
+Whilst Simphony-Remote is running using the standard ``jupyter_config.py`` script,
+navigate to https://127.0.0.1:8000 in your browser and login with the username 'admin' and no password. Select the
+'Users' tab on the left hand menu and click the 'Create New Entry' button in the top right. Make up a username and
+click submit. 
+
+Next, click the Applications tab in the left hand menu and click the 'Create New Entry' button in the top right.
+We can add the name of any docker image available to the Docker daemon.
+
+Then go back to the 'Users' tab, select the 'Policies' button next to the username. Create a new entry and choose
+the added image name from the dropdown menu. Nothing else needs to be set, unless you want to mount a directory
+within the docker container.
+
+Log out of SimphonyRemote (red 'admin' button in the top right) and log in using the username you specified for your
+new user and no password, you should now be able to start your application!

--- a/ci/Dockerfile-centos
+++ b/ci/Dockerfile-centos
@@ -1,0 +1,29 @@
+FROM centos:7
+
+MAINTAINER SimPhoNy Team
+WORKDIR /simphony-remote
+COPY . /simphony-remote
+
+RUN yum update -y && \
+    yum install -y yum-utils && \
+    yum upgrade -y && \
+    yum install -y git sudo make
+
+RUN make deps
+
+ENV LC_ALL=en_GB.utf8
+ENV LANG=C.UTF-8
+
+ENV VIRTUAL_ENV /simphony-remote/venv
+RUN make venv
+ENV PATH $VIRTUAL_ENV/bin:$PATH
+
+RUN npm install bower
+RUN make pythondeps
+
+RUN make install
+RUN make certs
+RUN make db
+RUN mkdir /tmp/remoteapp
+
+EXPOSE 8000

--- a/ci/Dockerfile-ubuntu
+++ b/ci/Dockerfile-ubuntu
@@ -1,0 +1,29 @@
+FROM ubuntu:18.04
+
+MAINTAINER SimPhoNy Team
+WORKDIR /simphony-remote
+COPY . /simphony-remote
+
+RUN apt-get update -y && \
+    apt-get install -y apt-utils && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends git sudo make
+
+RUN make deps
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+ENV VIRTUAL_ENV /simphony-remote/venv
+RUN make venv
+ENV PATH $VIRTUAL_ENV/bin:$PATH
+
+RUN npm install bower
+RUN make pythondeps
+
+RUN make install
+RUN make certs
+RUN make db
+RUN mkdir /tmp/remoteapp
+
+EXPOSE 8000

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 flake8
 coverage
-selenium==2.53.6
+selenium==3.141.0

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,3 @@
-sphinx==1.4.4
 git+https://github.com/berkerpeksag/astor.git#egg=astor
+sphinx==1.4.4
 git+https://github.com/simphony/traitlet-documenter.git@v0.1.0#egg=traitlet_documenter

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/berkerpeksag/astor.git#egg=astor
 sphinx==1.4.4
+astor==0.8.1
 git+https://github.com/simphony/traitlet-documenter.git@v0.1.0#egg=traitlet_documenter

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -111,7 +111,6 @@ Setup docker containers
 To create new images, please follow the documentation hosted at Horizon 2020
 `Simphony <https://github.com/simphony/simphony-remote-docker>`_ project repository.
 
-.. _deploy_setup_db:
 
 Setup Database Accounting
 -------------------------

--- a/doc/source/deployment.rst
+++ b/doc/source/deployment.rst
@@ -8,17 +8,19 @@ Deployment of the complete system in a single machine/VM.
 
 .. note::
 
-   The following instructions assume a clean up-to-date ubuntu 14.04
-   system.
+   The following instructions assume a clean up-to-date Ubuntu 18.04 or CentOS 7
+   system with ``git`` and ``make`` installed.
 
-#. Retrieve the single user session manager::
+#. Retrieve the required repository::
 
-     git clone https://github.com/simphony/simphony-remote
+     git clone https://github.com/simphony/simphony-remote.git
 
-#. Make sure that you are obtaining a recent version of Docker, at least 1.12.
+#. Make sure that you have a recent version of Docker. This guide has been tested on version 19.03.5 (build 633a0ea838).
+   :code:`make deps` will install the latest version if you do not already have a version of docker available.
    Full instructions available at `the Docker website <https://docs.docker.com/engine/installation/linux/ubuntulinux/>`_.
-   A Makefile rule is provided for convenience. **NOTE: this overwrites the docker.list file you might have setup in your
-   /etc/apt/sources.d/ directory**. You might be prompted for the root password to execute this::
+   A Makefile rule is provided for convenience.
+   **NOTE: this overwrites the docker.list file you might have setup in your /etc/apt/sources.d/ directory**.
+   You might be prompted for the root password to execute this::
 
      make deps
 
@@ -37,7 +39,7 @@ Deployment of the complete system in a single machine/VM.
 
      make venv
      . venv/bin/activate
-     export PATH=`node bin`:$PATH
+     export PATH=`npm bin`:$PATH
 
 #. Install the python dependencies::
 
@@ -73,19 +75,41 @@ Deployment of the complete system in a single machine/VM.
 
 #. You can now start the service::
 
-     sh start.sh
+     bash start.sh
+
+    .. note::
+      If you want to keep the application running, use screen to start
+      a detachable terminal.
+
+   .. note::
+      Running on OSX or with a separate docker machine requires that the
+      appropriate environment variables are set before starting jupyterhub.
+      refer to the command ``docker-machine env`` to setup the appropriate
+      environment. In general, invoking::
+
+            eval `docker-machine env`
+
+      will enable the appropriate environment.
+      On Linux, by default the host machine and the docker machine coincide,
+      so this step is not needed.
+
+    Currently, the only fully supported browser is Google Chrome/Chromium. The latest version of Firefox has shown
+    some issues with keyboard input when the vnc is running, however for the most part users will likley not
+    suffer any issues.
 
 #. Visit the site at::
 
     https://127.0.0.1:8000
 
+   For many browsers this must be typed exactly as shown - using http://127.0.0.1:8000 or localhost:8000
+   will not work. As mentioned above, the self-signed SSL certificates should cause your browser to 
+   raise a warning and require adding 127.0.0.1 to the list of security exceptions.  
 
 Setup docker containers
 -----------------------
 
-Compatible docker containers can be found in DockerHub. Refer to the documentation
-of `simphony-remote-docker <https://github.com/simphony/simphony-remote-docker>`_
-repository to deploy the images.
+To create new images, please follow the documentation hosted at Horizon 2020
+`Simphony <https://github.com/simphony/simphony-remote-docker>`_ project repository.
 
 .. _deploy_setup_db:
 
@@ -157,3 +181,45 @@ Start JupyterHub
       so this step is not needed.
 
 #. JupyterHub is now running at https://localhost:8000
+
+Using Nginx Reverse Proxy
+=========================
+
+Although the SimPhoNy-Remote installation will include ``nginx``, it is up to the developer to make sure that it is
+running correctly, with ``http`` and ``https`` firewall access also set up.
+
+To begin with, please first ensure that the following directories exist in your file system (you will need root
+privileges in order to do so)::
+
+  /etc/ssl/certs/
+  /etc/ssl/private/
+  /etc/nginx/conf.d/
+
+If you want to use self-signed certificates, you can run the following ``make`` command in order to generate a more
+secure set of RSA certificates and Diffie-Helman parameters for the Nginx reverse proxy::
+
+  make certs CERT_TYPE='nginx'
+  sudo mv nginx/certs/nginx-selfsigned.key /etc/ssl/private/
+  sudo mv nginx/certs/nginx-selfsigned.crt /etc/ssl/certs/
+  sudo mv nginx/certs/dhparam.pem /etc/ssl/certs/
+
+Then edit the ``nginx/nginx.conf.template`` file provided will in order to include a public IP address / server name
+in the sections marked ``<external server name>``. If you prefer to use authenticated certificates this is also the
+time to edit the ``ssl_certificate`` and ``ssl_certificate_key`` sections with the updated locations of these files.
+
+The Nginx template file will need to be copied into the following location (and given the ``.conf`` extension) in
+order to be discoverable by the ``nginx`` proxy::
+
+  sudo cp nginx/nginx.conf.template /etc/nginx/conf.d/sr-nginx.conf
+
+After restarting the ``nginx`` service to make sure the new configuration is applied, run SimPhoNy-Remote as normal
+and it will be discoverable at https://<external_server_name>
+
+Running as a Service
+====================
+
+Instructions for how to run a general JupyterHub deployment as a service can be found
+`here <https://github.com/jupyterhub/jupyterhub/wiki/Run-jupyterhub-as-a-system-service>`_.
+
+Instead of executing a ``jupyterhub <config.py> <flags>`` command upon starting the service, it is
+more advisable to call ``bash <simphony-remote>/jupterhub/start.sh`` instead.

--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -9,6 +9,7 @@ for each user.
 
 .. include::
     developer/docker.rst
+    developer/ci_instructions.rst
 
 API reference
 -------------

--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -7,9 +7,8 @@ RemoteAppManager
 The main tornado web application that manages the containers (docker applications)
 for each user.
 
-.. include::
-    developer/docker.rst
-    developer/ci_instructions.rst
+.. include:: developer/docker.rst
+.. include:: developer/ci_instructions.rst
 
 API reference
 -------------

--- a/doc/source/developer/ci_instructions.rst
+++ b/doc/source/developer/ci_instructions.rst
@@ -1,0 +1,41 @@
+Docker CI for SimPhoNy-Remote
+=============================
+
+This module contains Docker files that can be used to test installations
+for various platforms.
+
+Please ensure that you are building from a clean repository, since all contents will be copied into the Docker
+image and may affect the build. For example, if a ``venv`` is already present then this will prevent the
+Python virtual environment inside the container from being set up correctly.
+
+However, running S-R as a Docker container image is NOT fully supported for deployment, since image applications
+will not be able to be run.
+
+
+Building SimPhoNy-Remote as a Docker Image
+------------------------------------------
+
+It is also possible to build SimPhoNy-Remote as a Docker container image using a `Dockerfile` script
+provided for either `ubuntu` or `centos` Linux OS::
+
+    docker build . --file Dockerfile-<linux os> -t simphony-remote
+
+Alternatively, you can provide the following `docker-compose` command::
+
+    docker-compose build simphony-remote-<linux os>
+
+Running SimPhoNy-Remote as a Docker Image
+-----------------------------------------
+
+When running, S-R needs to be given a reference to the Docker daemon that contains the applications
+(also Docker container images) required by the Hub session. Running Docker inside Docker is not recommended,
+but there are a couple of approaches that can be used as a work around, such as
+`sharing volumes <https://docs.docker.com/storage/volumes>`_ or performing a
+`bind mount <https://docs.docker.com/storage/bind-mounts>`_.
+
+We have successfully ran a S-R session using a Docker container image by sharing volumes with the following command::
+
+    docker run -it -v /var/run/docker.sock:/var/run/docker.sock -p 8000:8000 simphony-remote-<linux os> bash
+
+This will allow a jupyterhub session with user login / management services to be initiated as normal. However, as
+stated previously, any S-R applications will not be able to run.

--- a/doc/source/troubleshoot/database.rst
+++ b/doc/source/troubleshoot/database.rst
@@ -1,6 +1,9 @@
 The database is not initalised properly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Each user's server requires a database setup and readable by the local process on which the :py:mod:`remoteappmanager` web application is started.  The error message indicates that the database is not readable (e.g. it does not exist).  Please refer to :ref:`deploy_setup_db` for details and options on setting up the database.
+Each user's server requires a database setup and readable by the local process on which the
+:py:mod:`remoteappmanager` web application is started.  The error message indicates that the database is
+not readable (e.g. it does not exist).  Please refer to `further documentation <doc/source/deployment>`_
+for details and options on setting up the database.
 
 For more details on how the local process is managed, please refers to :py:mod:`remoteappmanager.spawner`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  ubuntu:
+    image: ubuntu:18.04
+
+  centos:
+    image: centos:7
+
+  simphony-remote-ubuntu:
+    build:
+      context: .
+      dockerfile: ci/Dockerfile-ubuntu
+    image: simphony-remote-ubuntu
+    ports:
+      - "8000:8000"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  simphony-remote-centos:
+    build:
+      context: .
+      dockerfile: ci/Dockerfile-centos
+    image: simphony-remote-centos
+    ports:
+      - "8000:8000"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/frontend/admin/vue-components/AccountingView.vue
+++ b/frontend/admin/vue-components/AccountingView.vue
@@ -52,7 +52,7 @@
       return {
         table: {
           headers: [
-            "ID", "Image", "Workspace", "Vol. source", "Vol. target", "Readonly"
+            "ID", "Image", "License", "Workspace", "Vol. source", "Vol. target", "Readonly"
           ],
           columnFormatters: [undefined, undefined, checkIconFormatter, undefined, undefined, checkIconFormatter],
           rows: [],
@@ -95,6 +95,7 @@
             this.table.rows.push([
               id,
               item.image_name,
+              item.app_license,
               item.allow_home,
               item.volume_source,
               item.volume_target,

--- a/frontend/admin/vue-components/accounting/NewAccountingDialog.vue
+++ b/frontend/admin/vue-components/accounting/NewAccountingDialog.vue
@@ -16,6 +16,11 @@
         </validate>
 
         <div class="form-group">
+            <label for="app_license">License</label>
+            <textarea class="form-control" name="app_license" placeholder="Enter license key here if required" v-model="model.app_license"></textarea>
+        </div>
+
+        <div class="form-group">
           <label>
             <input type="checkbox" id="allow_home" v-model="model.allow_home"/> Mount home as Workspace
           </label>
@@ -73,6 +78,7 @@
         communicationError: null,
         model: {
           image_name: '',
+          app_license: '',
           allow_home: false,
           volume_source: '',
           volume_target: '',
@@ -126,6 +132,7 @@
         let rep = {
           user_id: this.userId,
           image_name: this.model.image_name,
+          app_license: this.model.app_license,
           allow_home: this.model.allow_home,
           volume_source: this.model.volume_source,
           volume_target: this.model.volume_target,

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -1,0 +1,51 @@
+# Adapted from https://github.com/jupyterhub/jupyterhub/blob/master/docs/source/reference/config-proxy.md
+
+#top-level http config for websocket headers
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+        ''      close;
+}
+
+
+# All regular http requests on port 80 become SSL/HTTPS requests on port 32
+server {
+    listen 80;
+    server_name <external server name>;
+
+    # Tell all requests to port 80 to be 302 redirected to HTTPS
+    return 302 https://$host$request_uri;
+}
+
+server {
+
+    listen 443 ssl;
+
+    server_name <external server name>;
+
+    ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+	ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    add_header Strict-Transport-Security max-age=15768000;
+
+	# Managing literal requests to the JupyterHub front end
+	location / {
+	    # Note: this url uses https, since we are working on an older version of JupyterHub (< 0.8.0), which
+	    # internall uses the deprecated jupyterhub.orm.Proxy class. It is expected that updating the version
+	    # to > 0.8.0 will mean using a http address instead, since this is replaced by the
+	    # jupyterhub.proxy.ConfigurableHTTPProxy class instead
+		proxy_pass https://127.0.0.1:8000;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header Host $host;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD",
   "repository": {
     "type": "git",
-    "url": "https://github.com/simphony-remote/simphony-remote.git"
+    "url": "https://github.com/simphony/simphony-remote.git"
   },
   "scripts": {
     "watch": "webpack --config webpackfile.js --watch",
@@ -17,11 +17,11 @@
   "dependencies": {
     "admin-lte": "~2.3.11",
     "clipboard": "~1.6.1",
-    "configurable-http-proxy": "git://github.com/jupyterhub/configurable-http-proxy.git#2.0.1",
+    "configurable-http-proxy": "~2.0.1",
     "font-awesome": "~4.7.0",
     "ionicons": "~3.0.0",
     "lodash": "~4.17.4",
-    "url-parse": "~1.1.9",
+    "url-parse": "^1.4.7",
     "vue": "~2.3.3",
     "vue-form": "~4.1.0",
     "vue-router": "~2.5.3"

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -132,6 +132,10 @@ class BaseApplication(web.Application, LoggingMixin):
         login_service = self.command_line_config.login_service
         user = User(name=user_name, login_service=login_service)
         user.account = self.db.get_user(user_name=user_name)
+
+        self.log.info("Adding demo apps to User registry:")
+        self._add_demo_apps(user)
+
         return user
 
     @default("registry")
@@ -145,9 +149,6 @@ class BaseApplication(web.Application, LoggingMixin):
     # Public
     def start(self):
         """Start the application and the ioloop"""
-
-        self.log.info("Adding demo apps to User registry:")
-        self._add_demo_apps()
 
         self.log.info("Starting server with options:")
         for trait_name in self._command_line_config.trait_names():
@@ -165,19 +166,19 @@ class BaseApplication(web.Application, LoggingMixin):
         tornado.ioloop.IOLoop.current().start()
 
     # Private
-    def _add_demo_apps(self):
+    def _add_demo_apps(self, user):
         """Grant access to any demo applications provided for user"""
 
-        if not self.user.demo_applications:
+        if user.demo_applications:
             return
 
         # Add all demo applications already registered
         for application in self.db.list_applications():
-            if application.image in self.user.demo_applications:
+            if application.image in user.demo_applications:
                 self.log.info(application.image)
                 self.db.grant_access(
                     application.image,
-                    self.user.name,
+                    user.name,
                     False,
                     True,
                     None

--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -222,7 +222,7 @@ def list(ctx, no_decoration, show_apps):
         format = "simple"
         headers = ["ID", "Name"]
         if show_apps:
-            headers += ["App", "Home", "View", "Common", "Vol. Source",
+            headers += ["App", "License", "Home", "View", "Common", "Vol. Source",
                         "Vol. Target", "Vol. Mode"]
 
     session = ctx.obj.session
@@ -234,6 +234,7 @@ def list(ctx, no_decoration, show_apps):
             table.append(cur)
             if show_apps:
                 apps = [[entry.application.image,
+                         entry.application_policy.app_license,
                          entry.application_policy.allow_home,
                          entry.application_policy.allow_view,
                          entry.application_policy.allow_common,
@@ -243,7 +244,7 @@ def list(ctx, no_decoration, show_apps):
                         for entry in orm.accounting_for_user(session, user)]
 
                 if len(apps) == 0:
-                    apps = [['']*7]
+                    apps = [['']*8]
 
                 cur.extend(apps[0])
                 for app in apps[1:]:
@@ -340,6 +341,8 @@ def list(ctx, no_decoration):
 @app.command()
 @click.argument("image")
 @click.argument("user")
+@click.option("--app_license", type=click.STRING,
+              help="Application license (if required)")
 @click.option("--allow-home",
               is_flag=True,
               help="Enable mounting of home directory")
@@ -350,7 +353,7 @@ def list(ctx, no_decoration):
               help="Application data volume, format=SOURCE:TARGET:MODE, "
                    "where mode is 'ro' or 'rw'.")
 @click.pass_context
-def grant(ctx, image, user, allow_home, allow_view, volume):
+def grant(ctx, image, user, app_license, allow_home, allow_view, volume):
     """Grants access to application identified by IMAGE to a specific
     user USER and specified access policy."""
     allow_common = False
@@ -380,6 +383,7 @@ def grant(ctx, image, user, allow_home, allow_view, volume):
                                      param_hint="user")
 
         orm_policy = session.query(orm.ApplicationPolicy).filter(
+            orm.ApplicationPolicy.app_license == app_license,
             orm.ApplicationPolicy.allow_home == allow_home,
             orm.ApplicationPolicy.allow_common == allow_common,
             orm.ApplicationPolicy.allow_view == allow_view,
@@ -389,6 +393,7 @@ def grant(ctx, image, user, allow_home, allow_view, volume):
 
         if orm_policy is None:
             orm_policy = orm.ApplicationPolicy(
+                app_license=app_license,
                 allow_home=allow_home,
                 allow_common=allow_common,
                 allow_view=allow_view,
@@ -423,6 +428,8 @@ def grant(ctx, image, user, allow_home, allow_view, volume):
               is_flag=True,
               help="revoke all grants for that specific user and application, "
                    "regardless of policy.")
+@click.option("--app_license", type=click.STRING,
+              help="Application license (if required)")
 @click.option("--allow-home",
               is_flag=True,
               help="Policy for mounting of home directory")
@@ -434,7 +441,7 @@ def grant(ctx, image, user, allow_home, allow_view, volume):
               help="Application data volume, format=SOURCE:TARGET:MODE, "
                    "where mode is 'ro' or 'rw'.")
 @click.pass_context
-def revoke(ctx, image, user, revoke_all, allow_home, allow_view, volume):
+def revoke(ctx, image, user, revoke_all, app_license, allow_home, allow_view, volume):
     """Revokes access to application identified by IMAGE to a specific
     user USER and specified parameters."""
     allow_common = False
@@ -463,6 +470,7 @@ def revoke(ctx, image, user, revoke_all, allow_home, allow_view, volume):
 
         else:
             orm_policy = session.query(orm.ApplicationPolicy).filter(
+                orm.ApplicationPolicy.app_license == app_license,
                 orm.ApplicationPolicy.allow_home == allow_home,
                 orm.ApplicationPolicy.allow_common == allow_common,
                 orm.ApplicationPolicy.allow_view == allow_view,

--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -91,7 +91,7 @@ def get_docker_client():
         # ConnectionError occurs, say, if the docker machine is not running
         # or if the shell is not in a docker VM (for Mac/Windows)
         print_error('docker client fails to connect.')
-        raise
+        raise exception
 
     return client
 
@@ -222,8 +222,8 @@ def list(ctx, no_decoration, show_apps):
         format = "simple"
         headers = ["ID", "Name"]
         if show_apps:
-            headers += ["App", "License", "Home", "View", "Common", "Vol. Source",
-                        "Vol. Target", "Vol. Mode"]
+            headers += ["App", "License", "Home", "View", "Common",
+                        "Vol. Source", "Vol. Target", "Vol. Mode"]
 
     session = ctx.obj.session
 
@@ -441,7 +441,9 @@ def grant(ctx, image, user, app_license, allow_home, allow_view, volume):
               help="Application data volume, format=SOURCE:TARGET:MODE, "
                    "where mode is 'ro' or 'rw'.")
 @click.pass_context
-def revoke(ctx, image, user, revoke_all, app_license, allow_home, allow_view, volume):
+def revoke(
+        ctx, image, user, revoke_all, app_license,
+        allow_home, allow_view, volume):
     """Revokes access to application identified by IMAGE to a specific
     user USER and specified parameters."""
     allow_common = False

--- a/remoteappmanager/cli/tests/test_remoteappdb.py
+++ b/remoteappmanager/cli/tests/test_remoteappdb.py
@@ -1,6 +1,6 @@
 import os
-from tornado.testing import LogTrapTestCase
-from unittest import mock
+from tornado.testing import ExpectLog
+from unittest import mock, TestCase
 
 from click.testing import CliRunner
 
@@ -14,7 +14,7 @@ def create_docker_client():
     return VirtualDockerClient.with_containers()
 
 
-class TestRemoteAppDbCLI(TempMixin, LogTrapTestCase):
+class TestRemoteAppDbCLI(TempMixin, ExpectLog, TestCase):
     def setUp(self):
         super().setUp()
         self.db = os.path.join(self.tempdir, "test.db")

--- a/remoteappmanager/cli/tests/test_remoteappdb.py
+++ b/remoteappmanager/cli/tests/test_remoteappdb.py
@@ -1,5 +1,4 @@
 import os
-from tornado.testing import ExpectLog
 from unittest import mock, TestCase
 
 from click.testing import CliRunner
@@ -14,9 +13,9 @@ def create_docker_client():
     return VirtualDockerClient.with_containers()
 
 
-class TestRemoteAppDbCLI(TempMixin, ExpectLog, TestCase):
+class TestRemoteAppDbCLI(TempMixin, TestCase):
     def setUp(self):
-        super().setUp()
+        super(TestRemoteAppDbCLI, self).setUp()
         self.db = os.path.join(self.tempdir, "test.db")
         self._remoteappdb("init")
 

--- a/remoteappmanager/command_line_config.py
+++ b/remoteappmanager/command_line_config.py
@@ -44,7 +44,8 @@ class CommandLineConfig(HasTraits):
     config_file = Unicode(help="The path of the configuration file")
 
     #: A reference to the authenticator class used for the user login
-    login_service = Unicode(help="The name of the JupyterHub Authenticator class")
+    login_service = Unicode(
+        help="The name of the JupyterHub Authenticator class")
 
     # Used to keep track if we already added the options
     # to the global config object. If that's the case, we skip the addition
@@ -58,12 +59,12 @@ class CommandLineConfig(HasTraits):
         """
 
         if not self.command_line_options_inited:
-            for traitlet_name, traitlet in self.traits().items():
+            for trait_name, trait in self.traits().items():
                     define(
-                        traitlet_name,
-                        default=traitlet.default_value,
-                        type=type(traitlet.default_value),
-                        help=traitlet.help)
+                        trait_name,
+                        default=trait.default_value,
+                        type=type(trait.default_value),
+                        help=trait.help)
 
         self.__class__.command_line_options_inited = True
 

--- a/remoteappmanager/command_line_config.py
+++ b/remoteappmanager/command_line_config.py
@@ -60,11 +60,11 @@ class CommandLineConfig(HasTraits):
 
         if not self.command_line_options_inited:
             for trait_name, trait in self.traits().items():
-                    define(
-                        trait_name,
-                        default=trait.default_value,
-                        type=type(trait.default_value),
-                        help=trait.help)
+                define(
+                    trait_name,
+                    default=trait.default_value,
+                    type=type(trait.default_value),
+                    help=trait.help)
 
         self.__class__.command_line_options_inited = True
 

--- a/remoteappmanager/command_line_config.py
+++ b/remoteappmanager/command_line_config.py
@@ -37,7 +37,14 @@ class CommandLineConfig(HasTraits):
     # The full URL where to access the reverse proxy API.
     proxy_api_url = Unicode(help="The url of the reverse proxy API")
 
+    # The full URL for logging out of JupyterHub (typically determined by an
+    # Authenticator class)
+    logout_url = Unicode(help="The logout url of the jupyterhub")
+
     config_file = Unicode(help="The path of the configuration file")
+
+    #: A reference to the authenticator class used for the user login
+    login_service = Unicode(help="The name of the JupyterHub Authenticator class")
 
     # Used to keep track if we already added the options
     # to the global config object. If that's the case, we skip the addition

--- a/remoteappmanager/db/csv_db.py
+++ b/remoteappmanager/db/csv_db.py
@@ -79,7 +79,7 @@ class CSVUser(object):
 # Required headers of the CSV files
 _HEADERS = ('user.name',
             'application.image',
-            'policy.app_license'
+            'policy.app_license',
             'policy.allow_home',
             'policy.allow_view',
             'policy.allow_common',

--- a/remoteappmanager/db/csv_db.py
+++ b/remoteappmanager/db/csv_db.py
@@ -221,11 +221,11 @@ class CSVDatabase(ABCDatabase):
     def list_applications(self):
         return list(self.applications.values())
 
-    def grant_access(self, app_name, user_name,
+    def grant_access(self, app_name, user_name, app_license,
                      allow_home, allow_view, volume):
         raise UnsupportedOperation()
 
-    def revoke_access(self, app_name, user_name,
+    def revoke_access(self, app_name, user_name, app_license,
                       allow_home, allow_view, volume):
         raise UnsupportedOperation()
 

--- a/remoteappmanager/db/csv_db.py
+++ b/remoteappmanager/db/csv_db.py
@@ -147,8 +147,8 @@ class CSVDatabase(ABCDatabase):
                         image=image
                     )
                 )
-                app_license = (record[indices['policy.app_license']] or
-                                 None)
+                app_license = (
+                    record[indices['policy.app_license']] or None)
                 allow_home = record[indices['policy.allow_home']] == '1'
                 allow_view = record[indices['policy.allow_view']] == '1'
                 allow_common = record[indices['policy.allow_common']] == '1'

--- a/remoteappmanager/db/csv_db.py
+++ b/remoteappmanager/db/csv_db.py
@@ -10,6 +10,9 @@ user.name (str)
 application.image (str)
     Image name of the application.
 
+policy.app_license (str)
+    String containing application license (if required)
+
 policy.allow_home (str)
     Is home directory mounted (1 - true, 0 - false).
 
@@ -76,6 +79,7 @@ class CSVUser(object):
 # Required headers of the CSV files
 _HEADERS = ('user.name',
             'application.image',
+            'policy.app_license'
             'policy.allow_home',
             'policy.allow_view',
             'policy.allow_common',
@@ -143,7 +147,8 @@ class CSVDatabase(ABCDatabase):
                         image=image
                     )
                 )
-
+                app_license = (record[indices['policy.app_license']] or
+                                 None)
                 allow_home = record[indices['policy.allow_home']] == '1'
                 allow_view = record[indices['policy.allow_view']] == '1'
                 allow_common = record[indices['policy.allow_common']] == '1'
@@ -155,13 +160,15 @@ class CSVDatabase(ABCDatabase):
                                None)
 
                 application_policy = self.application_policies.setdefault(
-                    (allow_home,
+                    (app_license,
+                     allow_home,
                      allow_view,
                      allow_common,
                      volume_source,
                      volume_target,
                      volume_mode),
                     CSVApplicationPolicy(
+                        app_license=app_license,
                         allow_home=allow_home,
                         allow_view=allow_view,
                         allow_common=allow_common,

--- a/remoteappmanager/db/interfaces.py
+++ b/remoteappmanager/db/interfaces.py
@@ -25,10 +25,14 @@ class ABCApplicationPolicy(metaclass=ABCMeta):
     """ Policy for an application
     """
 
-    def __init__(self, app_license=None, allow_home=False, allow_view=False, allow_common=False,
-                 volume_source=None, volume_target=None, volume_mode=None):
+    def __init__(self, app_license=None, allow_home=False, allow_view=False,
+                 allow_common=False, volume_source=None, volume_target=None,
+                 volume_mode=None):
 
         #: Application License (if specified)
+        if app_license is None:
+            app_license = ''
+
         self.app_license = app_license
 
         #: Is the home directory mounted

--- a/remoteappmanager/db/interfaces.py
+++ b/remoteappmanager/db/interfaces.py
@@ -25,8 +25,11 @@ class ABCApplicationPolicy(metaclass=ABCMeta):
     """ Policy for an application
     """
 
-    def __init__(self, allow_home=False, allow_view=False, allow_common=False,
+    def __init__(self, app_license=None, allow_home=False, allow_view=False, allow_common=False,
                  volume_source=None, volume_target=None, volume_mode=None):
+
+        #: Application License (if specified)
+        self.app_license = app_license
 
         #: Is the home directory mounted
         self.allow_home = allow_home

--- a/remoteappmanager/db/interfaces.py
+++ b/remoteappmanager/db/interfaces.py
@@ -198,7 +198,7 @@ class ABCDatabase(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def grant_access(self, app_name, user_name,
+    def grant_access(self, app_name, user_name, app_license,
                      allow_home, allow_view, volume):
         """Grant access for user to application.
 
@@ -209,6 +209,9 @@ class ABCDatabase(metaclass=ABCMeta):
 
         user_name: str
             The name of the user
+
+        app_license: str
+            The license of a commercial application
 
         allow_home: bool
             If the home workspace should be mounted.
@@ -235,7 +238,7 @@ class ABCDatabase(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def revoke_access(self, app_name, user_name,
+    def revoke_access(self, app_name, user_name, app_license,
                       allow_home, allow_view, volume):
         """Revoke access for user to application.
 
@@ -246,6 +249,9 @@ class ABCDatabase(metaclass=ABCMeta):
 
         user_name: str
             The name of the user
+
+        app_license: str
+            The license of a commercial application
 
         allow_home: bool
             If the home workspace should be mounted.

--- a/remoteappmanager/db/interfaces.py
+++ b/remoteappmanager/db/interfaces.py
@@ -30,9 +30,6 @@ class ABCApplicationPolicy(metaclass=ABCMeta):
                  volume_mode=None):
 
         #: Application License (if specified)
-        if app_license is None:
-            app_license = ''
-
         self.app_license = app_license
 
         #: Is the home directory mounted

--- a/remoteappmanager/db/orm.py
+++ b/remoteappmanager/db/orm.py
@@ -409,9 +409,8 @@ class ORMDatabase(ABCDatabase):
     def revoke_access_by_id(self, mapping_id):
         with detached_session(self.db) as session, \
                 transaction(session):
-                session.query(Accounting).filter(
-                    Accounting.id == mapping_id
-                    ).delete()
+            session.query(Accounting).filter(
+                Accounting.id == mapping_id).delete()
 
 
 @contextlib.contextmanager

--- a/remoteappmanager/db/orm.py
+++ b/remoteappmanager/db/orm.py
@@ -54,6 +54,10 @@ class Application(IdMixin, Base):
 
 class ApplicationPolicy(IdMixin, Base):
     __tablename__ = "application_policy"
+
+    #: License, if required by the application
+    app_license = Column(Unicode, nullable=True)
+
     #: If the home directory should be mounted in the container
     allow_home = Column(Boolean)
 
@@ -303,7 +307,7 @@ class ORMDatabase(ABCDatabase):
 
         return applications
 
-    def grant_access(self, app_name, user_name,
+    def grant_access(self, app_name, user_name, app_license,
                      allow_home, allow_view, volume):
         allow_common = False
         source = target = mode = None
@@ -324,6 +328,7 @@ class ORMDatabase(ABCDatabase):
                     raise exceptions.NotFound()
 
                 orm_policy = session.query(ApplicationPolicy).filter(
+                    ApplicationPolicy.app_license == app_license,
                     ApplicationPolicy.allow_home == allow_home,
                     ApplicationPolicy.allow_common == allow_common,
                     ApplicationPolicy.allow_view == allow_view,
@@ -333,6 +338,7 @@ class ORMDatabase(ABCDatabase):
 
                 if orm_policy is None:
                     orm_policy = ApplicationPolicy(
+                        app_license=app_license,
                         allow_home=allow_home,
                         allow_common=allow_common,
                         allow_view=allow_view,
@@ -365,7 +371,7 @@ class ORMDatabase(ABCDatabase):
 
                 return id
 
-    def revoke_access(self, app_name, user_name,
+    def revoke_access(self, app_name, user_name, app_license,
                       allow_home, allow_view, volume):
         allow_common = False
         source = target = mode = None
@@ -384,6 +390,7 @@ class ORMDatabase(ABCDatabase):
                     User.name == user_name).one()
 
                 orm_policy = session.query(ApplicationPolicy).filter(
+                    ApplicationPolicy.app_license == app_license,
                     ApplicationPolicy.allow_home == allow_home,
                     ApplicationPolicy.allow_common == allow_common,
                     ApplicationPolicy.allow_view == allow_view,

--- a/remoteappmanager/db/tests/abc_test_interfaces.py
+++ b/remoteappmanager/db/tests/abc_test_interfaces.py
@@ -145,7 +145,7 @@ class ABCTestDatabaseInterface(metaclass=ABCMeta):
 
         for method in [db.grant_access, db.revoke_access]:
             with self.assertRaises(exceptions.UnsupportedOperation):
-                method("bonkers", "uuu", True, False, "/a:/b:ro")
+                method("bonkers", "uuu", 'key', True, False, "/a:/b:ro")
 
         with self.assertRaises(exceptions.UnsupportedOperation):
             db.revoke_access_by_id(12345)

--- a/remoteappmanager/db/tests/test_csv_db.py
+++ b/remoteappmanager/db/tests/test_csv_db.py
@@ -9,16 +9,17 @@ from remoteappmanager.tests.temp_mixin import TempMixin
 
 
 class GoodTable:
-    headers = ('user.name', 'application.image', 'policy.allow_home',
-               'policy.allow_view', 'policy.allow_common',
+    headers = ('user.name', 'application.image', 'policy.app_license',
+               'policy.allow_home', 'policy.allow_view',
+               'policy.allow_common',
                'policy.volume_source', 'policy.volume_target',
                'policy.volume_mode')
 
     #    name,     image, home, view, common, source, target, mode
     records = [
-        ('markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '1', '1', '0', '', '', ''),  # noqa
-        ('markdoe', 'simphonyproject/ubuntu-image:latest', '1', '1', '1', '/src', '/target', 'ro'),  # noqa
-        ('johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '0', '0', '0', '/src', '/target', 'ro')]  # noqa
+        ('markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '', '1', '1', '0', '', '', ''),  # noqa
+        ('markdoe', 'simphonyproject/ubuntu-image:latest', '', '1', '1', '1', '/src', '/target', 'ro'),  # noqa
+        ('johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '', '0', '0', '0', '/src', '/target', 'ro')]  # noqa
 
 
 class BadTableMissingHeaders:
@@ -37,7 +38,8 @@ class BadTableMissingHeaders:
 class GoodTableWithDifferentHeaders:
     # There is an extra column and the columns order are different
     # but that's okay
-    headers = ('policy.allow_view', 'policy.allow_common',
+    headers = ('policy.app_license', 'policy.allow_view',
+               'policy.allow_common',
                'policy.volume_source', 'policy.volume_target',
                'policy.volume_mode',
                'user.name', 'application.image', 'policy.allow_home',
@@ -45,9 +47,9 @@ class GoodTableWithDifferentHeaders:
 
     #  view, common, source, target, mode, name, image, home, extra
     records = [
-        ('1', '0', '', '', '', 'markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '1', 'anything'),  # noqa
-        ('1', '1', '/src', '/target', 'ro', 'markdoe', 'simphonyproject/ubuntu-image:latest', '1', 'extra'),  # noqa
-        ('0', '0', '/src', '/target', 'ro', 'johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '0', 'abc')]  # noqa
+        ('', '1', '0', '', '', '', 'markdoe', 'simphonyproject/simphony-mayavi:0.6.0', '1', 'anything'),  # noqa
+        ('', '1', '1', '/src', '/target', 'ro', 'markdoe', 'simphonyproject/ubuntu-image:latest', '1', 'extra'),  # noqa
+        ('', '0', '0', '/src', '/target', 'ro', 'johndoe', 'simphonyproject/simphony-mayavi:0.6.0', '0', 'abc')]  # noqa
 
 
 def write_csv_file(file_name, headers, records):

--- a/remoteappmanager/db/tests/test_interfaces.py
+++ b/remoteappmanager/db/tests/test_interfaces.py
@@ -72,11 +72,11 @@ class Database(ABCDatabase):
                 Application(id=3, image="bar2")
                 ]
 
-    def grant_access(self, app_name, user_name,
+    def grant_access(self, app_name, user_name, app_license,
                      allow_home, allow_view, volume):
         raise exceptions.UnsupportedOperation()
 
-    def revoke_access(self, app_name, user_name,
+    def revoke_access(self, app_name, user_name, app_license,
                       allow_home, allow_view, volume):
         raise exceptions.UnsupportedOperation()
 

--- a/remoteappmanager/db/tests/test_orm.py
+++ b/remoteappmanager/db/tests/test_orm.py
@@ -1,8 +1,9 @@
 import contextlib
 import uuid
 import os
+from unittest import TestCase
 
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 
 from remoteappmanager.db import orm
 from remoteappmanager.db import exceptions
@@ -54,7 +55,7 @@ def fill_db(session):
         session.add_all(accountings)
 
 
-class TestOrm(TempMixin, LogTrapTestCase):
+class TestOrm(TempMixin, ExpectLog, TestCase):
     def setUp(self):
         super().setUp()
         self.sqlite_file_path = os.path.join(self.tempdir, "sqlite.db")
@@ -140,7 +141,7 @@ class TestOrm(TempMixin, LogTrapTestCase):
 
 
 class TestOrmDatabase(TempMixin, ABCTestDatabaseInterface,
-                      LogTrapTestCase):
+                      ExpectLog, TestCase):
     def setUp(self):
         # Setup temporary directory
         super().setUp()

--- a/remoteappmanager/db/tests/test_orm.py
+++ b/remoteappmanager/db/tests/test_orm.py
@@ -55,7 +55,7 @@ def fill_db(session):
         session.add_all(accountings)
 
 
-class TestOrm(TempMixin, ExpectLog, TestCase):
+class TestOrm(TempMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.sqlite_file_path = os.path.join(self.tempdir, "sqlite.db")
@@ -141,7 +141,7 @@ class TestOrm(TempMixin, ExpectLog, TestCase):
 
 
 class TestOrmDatabase(TempMixin, ABCTestDatabaseInterface,
-                      ExpectLog, TestCase):
+                      TestCase):
     def setUp(self):
         # Setup temporary directory
         super().setUp()

--- a/remoteappmanager/db/tests/test_orm.py
+++ b/remoteappmanager/db/tests/test_orm.py
@@ -322,24 +322,28 @@ class TestOrmDatabase(TempMixin, ABCTestDatabaseInterface,
         database = self.create_database()
 
         with self.assertRaises(exceptions.NotFound):
-            database.grant_access("simphonyremote/amazing", "ciccio",
-                                  True, False, "/foo:/bar:ro")
+            database.grant_access(
+                "simphonyremote/amazing", "ciccio", '',
+                True, False, "/foo:/bar:ro")
         database.create_user("ciccio")
 
         with self.assertRaises(exceptions.NotFound):
-            database.grant_access("simphonyremote/amazing", "ciccio",
-                                  True, False, "/foo:/bar:ro")
+            database.grant_access(
+                "simphonyremote/amazing", "ciccio", '',
+                True, False, "/foo:/bar:ro")
 
         database.create_application("simphonyremote/amazing")
 
-        id = database.grant_access("simphonyremote/amazing", "ciccio",
-                                   True, False, "/foo:/bar:ro")
+        id = database.grant_access(
+            "simphonyremote/amazing", "ciccio", 'some_key',
+            True, False, "/foo:/bar:ro")
         self.assertIsNotNone(id)
 
         user = database.get_user(user_name="ciccio")
         acc = database.get_accounting_for_user(user)
         self.assertEqual(acc[0].id, id)
         self.assertEqual(acc[0].application.image, "simphonyremote/amazing")
+        self.assertEqual(acc[0].application_policy.app_license, 'some_key')
         self.assertEqual(acc[0].application_policy.allow_home, True)
         self.assertEqual(acc[0].application_policy.allow_view, False)
         self.assertEqual(acc[0].application_policy.volume_source, "/foo")
@@ -347,38 +351,44 @@ class TestOrmDatabase(TempMixin, ABCTestDatabaseInterface,
         self.assertEqual(acc[0].application_policy.volume_mode, "ro")
 
         # Do it twice to check idempotency
-        id2 = database.grant_access("simphonyremote/amazing", "ciccio",
-                                    True, False, "/foo:/bar:ro")
+        id2 = database.grant_access(
+            "simphonyremote/amazing", "ciccio", 'some_key',
+            True, False, "/foo:/bar:ro")
         self.assertEqual(id, id2)
 
-        database.revoke_access("simphonyremote/amazing", "ciccio",
-                               True, False, "/foo:/bar:ro")
+        database.revoke_access(
+            "simphonyremote/amazing", "ciccio", 'some_key',
+            True, False, "/foo:/bar:ro")
 
         self.assertEqual(len(database.get_accounting_for_user(user)), 0)
 
         with self.assertRaises(exceptions.NotFound):
-            database.revoke_access("simphonyremote/amazing", "hello",
-                                   True, False, "/foo:/bar:ro")
+            database.revoke_access(
+                "simphonyremote/amazing", "hello", 'some_key',
+                True, False, "/foo:/bar:ro")
 
     def test_grant_revoke_access_volume(self):
         database = self.create_database()
 
         database.create_user("ciccio")
         database.create_application("simphonyremote/amazing")
-        database.grant_access("simphonyremote/amazing", "ciccio",
-                              True, False, None)
+        database.grant_access(
+            "simphonyremote/amazing", "ciccio", 'some_key',
+            True, False, None)
 
         user = database.get_user(user_name="ciccio")
         acc = database.get_accounting_for_user(user)
         self.assertEqual(acc[0].application.image, "simphonyremote/amazing")
+        self.assertEqual(acc[0].application_policy.app_license, 'some_key')
         self.assertEqual(acc[0].application_policy.allow_home, True)
         self.assertEqual(acc[0].application_policy.allow_view, False)
         self.assertEqual(acc[0].application_policy.volume_source, None)
         self.assertEqual(acc[0].application_policy.volume_target, None)
         self.assertEqual(acc[0].application_policy.volume_mode, None)
 
-        database.revoke_access("simphonyremote/amazing", "ciccio",
-                               True, False, None)
+        database.revoke_access(
+            "simphonyremote/amazing", "ciccio", 'some_key',
+            True, False, None)
 
         self.assertEqual(len(database.get_accounting_for_user(user)), 0)
 
@@ -387,8 +397,9 @@ class TestOrmDatabase(TempMixin, ABCTestDatabaseInterface,
 
         database.create_user("ciccio")
         database.create_application("simphonyremote/amazing")
-        id = database.grant_access("simphonyremote/amazing", "ciccio",
-                                   True, False, None)
+        id = database.grant_access(
+            "simphonyremote/amazing", "ciccio", 'some_key',
+            True, False, None)
 
         user = database.get_user(user_name="ciccio")
         apps = database.get_accounting_for_user(user)

--- a/remoteappmanager/db/tests/test_orm.py
+++ b/remoteappmanager/db/tests/test_orm.py
@@ -3,8 +3,6 @@ import uuid
 import os
 from unittest import TestCase
 
-from tornado.testing import ExpectLog
-
 from remoteappmanager.db import orm
 from remoteappmanager.db import exceptions
 from remoteappmanager.db.orm import (Database, transaction, Accounting,

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -1,7 +1,7 @@
 import os
 from unittest import mock
 
-from tornado.testing import AsyncTestCase, gen_test, ExpectLog
+from tornado.testing import AsyncTestCase, ExpectLog, gen_test
 
 from remoteappmanager.docker.container import Container
 from remoteappmanager.docker.docker_labels import SIMPHONY_NS_RUNINFO
@@ -14,7 +14,7 @@ from remoteappmanager.tests.mocking.virtual.docker_client import (
     VirtualDockerClient)
 
 
-class TestContainerManager(AsyncTestCase, ExpectLog):
+class TestContainerManager(AsyncTestCase):
     def setUp(self):
         super().setUp()
         self.manager = create_container_manager()
@@ -233,13 +233,14 @@ class TestContainerManager(AsyncTestCase, ExpectLog):
             good_path = os.path.abspath('.')
             volumes[good_path] = {'bind': '/target_vol3',
                                   'mode': 'ro'}
-
-            yield self.manager.start_container("johndoe",
-                                               "simphonyproject/simphony-mayavi:0.6.0",  # noqa
-                                               "5b34ce60d95742fa828cdced12b4c342",  # noqa
-                                               "/foo/bar",
-                                               volumes,
-                                               )
+            with ExpectLog('tornado.application', ''):
+                yield self.manager.start_container(
+                    "johndoe",
+                    "simphonyproject/simphony-mayavi:0.6.0",
+                    "5b34ce60d95742fa828cdced12b4c342",
+                    "/foo/bar",
+                    volumes,
+                )
 
             # Call args and keyword args that create_container receives
             args = docker_client.create_container.call_args
@@ -270,12 +271,15 @@ class TestContainerManager(AsyncTestCase, ExpectLog):
             self.assertFalse(self.mock_docker_client.remove_container.called)
 
             with self.assertRaisesRegex(Exception, 'Boom!'):
-                yield self.manager.start_container("johndoe",
-                                                   "simphonyproject/simphony-mayavi:0.6.0",  # noqa
-                                                   "5b34ce60d95742fa828cdced12b4c342",  # noqa
-                                                   "/users/johndoe/containers/4273750ddce3454283a5b1817526260b/",  # noqa
-                                                   None,
-                                                   None)
+                with ExpectLog('tornado.application', ''):
+                    yield self.manager.start_container(
+                        "johndoe",
+                        "simphonyproject/simphony-mayavi:0.6.0",
+                        "5b34ce60d95742fa828cdced12b4c342",
+                        "/users/johndoe/containers/4273750ddce3454283a5b1817526260b/",  # noqa
+                        None,
+                        None
+                    )
 
             self.assertTrue(docker_client.stop.called)
             self.assertTrue(docker_client.remove_container.called)
@@ -298,12 +302,15 @@ class TestContainerManager(AsyncTestCase, ExpectLog):
             self.manager._docker_client.port = mock.Mock(side_effect=raiser)
 
             with self.assertRaisesRegex(Exception, 'Boom!'):
-                yield self.manager.start_container("johndoe",
-                                                   "simphonyproject/simphony-mayavi:0.6.0",  # noqa
-                                                   "4273750ddce3454283a5b1817526260b",  # noqa
-                                                   "/users/johndoe/containers/3b83f81f2e4544e6aa1493b50202f8eb",  # noqa
-                                                   None,
-                                                   None)
+                with ExpectLog('tornado.application', ''):
+                    yield self.manager.start_container(
+                        "johndoe",
+                        "simphonyproject/simphony-mayavi:0.6.0",
+                        "4273750ddce3454283a5b1817526260b",
+                        "/users/johndoe/containers/3b83f81f2e4544e6aa1493b50202f8eb",  # noqa
+                        None,
+                        None
+                    )
 
             self.assertTrue(self.mock_docker_client.stop.called)
             self.assertTrue(self.mock_docker_client.remove_container.called)
@@ -351,7 +358,9 @@ class TestContainerManager(AsyncTestCase, ExpectLog):
         self.mock_docker_client.remove_container = mock.Mock()
         manager = ContainerManager(docker_config={},
                                    realm="anotherrealm")
-        yield manager.stop_and_remove_container("d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30")  # noqa
+        with ExpectLog('tornado.application', ''):
+            yield manager.stop_and_remove_container(
+                "d2b56bffb5655cb7668b685b80116041a20ee8662ebfa5b5cb68cfc423d9dc30")  # noqa
 
         self.assertFalse(self.mock_docker_client.stop.called)
         self.assertFalse(self.mock_docker_client.remove_container.called)

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -9,6 +9,7 @@ from remoteappmanager.docker.container_manager import ContainerManager, \
     OperationInProgress
 from remoteappmanager.docker.image import Image
 from remoteappmanager.tests import utils
+from remoteappmanager.tests.mocking.dummy import create_container_manager
 from remoteappmanager.tests.mocking.virtual.docker_client import (
     VirtualDockerClient)
 
@@ -16,9 +17,8 @@ from remoteappmanager.tests.mocking.virtual.docker_client import (
 class TestContainerManager(AsyncTestCase, ExpectLog):
     def setUp(self):
         super().setUp()
-        self.manager = ContainerManager(docker_config={}, realm="myrealm")
-        self.mock_docker_client = VirtualDockerClient.with_containers()
-        self.manager._docker_client._sync_client = self.mock_docker_client
+        self.manager = create_container_manager()
+        self.mock_docker_client = self.manager._docker_client._sync_client
 
     def test_instantiation(self):
         self.assertIsNotNone(self.manager._docker_client)

--- a/remoteappmanager/docker/tests/test_container_manager.py
+++ b/remoteappmanager/docker/tests/test_container_manager.py
@@ -1,7 +1,7 @@
 import os
 from unittest import mock
 
-from tornado.testing import AsyncTestCase, gen_test, LogTrapTestCase
+from tornado.testing import AsyncTestCase, gen_test, ExpectLog
 
 from remoteappmanager.docker.container import Container
 from remoteappmanager.docker.docker_labels import SIMPHONY_NS_RUNINFO
@@ -13,7 +13,7 @@ from remoteappmanager.tests.mocking.virtual.docker_client import (
     VirtualDockerClient)
 
 
-class TestContainerManager(AsyncTestCase, LogTrapTestCase):
+class TestContainerManager(AsyncTestCase, ExpectLog):
     def setUp(self):
         super().setUp()
         self.manager = ContainerManager(docker_config={}, realm="myrealm")

--- a/remoteappmanager/handlers/admin/tests/test_admin_handlers.py
+++ b/remoteappmanager/handlers/admin/tests/test_admin_handlers.py
@@ -1,9 +1,9 @@
-from tornado.testing import ExpectLog
-from remoteappmanager.tests import utils
+from tornado.testing import ExpectLog, AsyncHTTPTestCase
+
 from remoteappmanager.tests.mocking import dummy
 
 
-class TestBaseAccess(utils.AsyncHTTPTestCase, ExpectLog):
+class TestBaseAccess(AsyncHTTPTestCase, ExpectLog):
     #: which url to poke
     url = "/user/johndoe"
 

--- a/remoteappmanager/handlers/admin/tests/test_admin_handlers.py
+++ b/remoteappmanager/handlers/admin/tests/test_admin_handlers.py
@@ -1,9 +1,9 @@
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 from remoteappmanager.tests import utils
 from remoteappmanager.tests.mocking import dummy
 
 
-class TestBaseAccess(utils.AsyncHTTPTestCase, LogTrapTestCase):
+class TestBaseAccess(utils.AsyncHTTPTestCase, ExpectLog):
     #: which url to poke
     url = "/user/johndoe"
 

--- a/remoteappmanager/handlers/base_handler.py
+++ b/remoteappmanager/handlers/base_handler.py
@@ -32,7 +32,7 @@ class BaseHandler(web.RequestHandler, LoggingMixin):
         args = dict(
             user=self.current_user,
             base_url=command_line_config.base_urlpath,
-            logout_url=urljoin(command_line_config.hub_prefix, "logout")
+            logout_url=command_line_config.logout_url
         )
 
         args.update(kwargs)

--- a/remoteappmanager/handlers/base_handler.py
+++ b/remoteappmanager/handlers/base_handler.py
@@ -1,5 +1,4 @@
 from http.client import responses
-from urllib.parse import urljoin
 import hashlib
 
 from tornado import web, gen

--- a/remoteappmanager/handlers/tests/test_base_handler.py
+++ b/remoteappmanager/handlers/tests/test_base_handler.py
@@ -1,4 +1,4 @@
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 from remoteappmanager.file_config import FileConfig
 
 from remoteappmanager.tests import utils
@@ -6,7 +6,7 @@ from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 
 
-class TestBaseHandler(TempMixin, utils.AsyncHTTPTestCase, LogTrapTestCase):
+class TestBaseHandler(TempMixin, utils.AsyncHTTPTestCase, ExpectLog):
     def get_file_config(self):
         file_config = FileConfig()
         file_config.database_class = \

--- a/remoteappmanager/handlers/tests/test_base_handler.py
+++ b/remoteappmanager/handlers/tests/test_base_handler.py
@@ -1,12 +1,11 @@
-from tornado.testing import ExpectLog
+from tornado.testing import ExpectLog, AsyncHTTPTestCase
 from remoteappmanager.file_config import FileConfig
 
-from remoteappmanager.tests import utils
 from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 
 
-class TestBaseHandler(TempMixin, utils.AsyncHTTPTestCase, ExpectLog):
+class TestBaseHandler(TempMixin, AsyncHTTPTestCase, ExpectLog):
     def get_file_config(self):
         file_config = FileConfig()
         file_config.database_class = \

--- a/remoteappmanager/handlers/tests/test_base_handler.py
+++ b/remoteappmanager/handlers/tests/test_base_handler.py
@@ -1,11 +1,11 @@
-from tornado.testing import ExpectLog, AsyncHTTPTestCase
+from tornado.testing import AsyncHTTPTestCase, ExpectLog
 from remoteappmanager.file_config import FileConfig
 
 from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 
 
-class TestBaseHandler(TempMixin, AsyncHTTPTestCase, ExpectLog):
+class TestBaseHandler(TempMixin, AsyncHTTPTestCase):
     def get_file_config(self):
         file_config = FileConfig()
         file_config.database_class = \
@@ -32,11 +32,13 @@ class TestBaseHandlerInvalidAccounting(TestBaseHandler):
         return file_config
 
     def test_home_internal_error(self):
-        res = self.fetch("/user/johndoe/",
-                         headers={
-                             "Cookie": "jupyter-hub-token-johndoe=foo"
-                         }
-                         )
+        with ExpectLog('tornado.application', ''), \
+                ExpectLog('tornado.access', ''):
+            res = self.fetch("/user/johndoe/",
+                             headers={
+                                 "Cookie": "jupyter-hub-token-johndoe=foo"
+                             }
+                             )
 
         self.assertEqual(res.code, 500)
         self.assertIn('Internal Server Error', str(res.body))
@@ -50,11 +52,13 @@ class TestBaseHandlerDatabaseError(TestBaseHandler):
         return file_config
 
     def test_home_internal_error(self):
-        res = self.fetch("/user/johndoe/",
-                         headers={
-                             "Cookie": "jupyter-hub-token-johndoe=foo"
-                         }
-                         )
+        with ExpectLog('tornado.application', ''), \
+                ExpectLog('tornado.access', ''):
+            res = self.fetch("/user/johndoe/",
+                             headers={
+                                 "Cookie": "jupyter-hub-token-johndoe=foo"
+                             }
+                             )
 
         self.assertEqual(res.code, 500)
         self.assertIn('Internal Server Error', str(res.body))

--- a/remoteappmanager/handlers/tests/test_register_container_handler.py
+++ b/remoteappmanager/handlers/tests/test_register_container_handler.py
@@ -1,4 +1,4 @@
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 
 from remoteappmanager.tests import utils
 from remoteappmanager.tests.mocking import dummy
@@ -8,7 +8,7 @@ from remoteappmanager.tests.utils import mock_coro_factory
 
 class TestRegisterContainerHandler(TempMixin,
                                    utils.AsyncHTTPTestCase,
-                                   LogTrapTestCase):
+                                   ExpectLog):
     def get_app(self):
         app = dummy.create_application()
         app.hub.verify_token.return_value = {

--- a/remoteappmanager/handlers/tests/test_register_container_handler.py
+++ b/remoteappmanager/handlers/tests/test_register_container_handler.py
@@ -1,13 +1,12 @@
-from tornado.testing import ExpectLog
+from tornado.testing import ExpectLog, AsyncHTTPTestCase
 
-from remoteappmanager.tests import utils
 from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 from remoteappmanager.tests.utils import mock_coro_factory
 
 
 class TestRegisterContainerHandler(TempMixin,
-                                   utils.AsyncHTTPTestCase,
+                                   AsyncHTTPTestCase,
                                    ExpectLog):
     def get_app(self):
         app = dummy.create_application()

--- a/remoteappmanager/handlers/tests/test_register_container_handler.py
+++ b/remoteappmanager/handlers/tests/test_register_container_handler.py
@@ -6,8 +6,7 @@ from remoteappmanager.tests.utils import mock_coro_factory
 
 
 class TestRegisterContainerHandler(TempMixin,
-                                   AsyncHTTPTestCase,
-                                   ExpectLog):
+                                   AsyncHTTPTestCase):
     def get_app(self):
         app = dummy.create_application()
         app.hub.verify_token.return_value = {
@@ -18,11 +17,11 @@ class TestRegisterContainerHandler(TempMixin,
         return app
 
     def test_absent_url_id(self):
-        res = self.fetch("/user/johndoe/containers/99999/",
-                         headers={
-                             "Cookie": "jupyter-hub-token-johndoe=foo"
-                         }
-                         )
+        with ExpectLog('tornado.access', ''):
+            res = self.fetch(
+                "/user/johndoe/containers/99999/",
+                headers={"Cookie": "jupyter-hub-token-johndoe=foo"}
+            )
 
         self.assertEqual(res.code, 404)
 
@@ -54,11 +53,11 @@ class TestRegisterContainerHandler(TempMixin,
         self._app.reverse_proxy.register = mock_coro_factory(
             side_effect=Exception("BOOM"))
 
-        res = self.fetch("/user/johndoe/containers/",
-                         headers={
-                             "Cookie": "jupyter-hub-token-johndoe=foo"
-                         },
-                         follow_redirects=False
-                         )
+        with ExpectLog('tornado.access', ''):
+            res = self.fetch(
+                "/user/johndoe/containers/",
+                headers={"Cookie": "jupyter-hub-token-johndoe=foo"},
+                follow_redirects=False
+            )
 
         self.assertEqual(res.code, 404)

--- a/remoteappmanager/handlers/tests/test_user_home_handler.py
+++ b/remoteappmanager/handlers/tests/test_user_home_handler.py
@@ -1,11 +1,11 @@
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 
 from remoteappmanager.tests import utils
 from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 
 
-class TestUserHomeHandler(TempMixin, utils.AsyncHTTPTestCase, LogTrapTestCase):
+class TestUserHomeHandler(TempMixin, utils.AsyncHTTPTestCase, ExpectLog):
     def get_app(self):
         app = dummy.create_application()
         app.hub.verify_token.return_value = {

--- a/remoteappmanager/handlers/tests/test_user_home_handler.py
+++ b/remoteappmanager/handlers/tests/test_user_home_handler.py
@@ -1,10 +1,10 @@
-from tornado.testing import ExpectLog, AsyncHTTPTestCase
+from tornado.testing import AsyncHTTPTestCase, ExpectLog
 
 from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 
 
-class TestUserHomeHandler(TempMixin, AsyncHTTPTestCase, ExpectLog):
+class TestUserHomeHandler(TempMixin, AsyncHTTPTestCase):
     def get_app(self):
         app = dummy.create_application()
         app.hub.verify_token.return_value = {
@@ -26,11 +26,12 @@ class TestUserHomeHandler(TempMixin, AsyncHTTPTestCase, ExpectLog):
 
     def test_failed_auth(self):
         self._app.hub.verify_token.return_value = {}
-        res = self.fetch("/user/johndoe/",
-                         headers={
-                             "Cookie": "jupyter-hub-token-johndoe=foo"
-                         }
-                         )
+        with ExpectLog('tornado.access', ''):
+            res = self.fetch("/user/johndoe/",
+                             headers={
+                                 "Cookie": "jupyter-hub-token-johndoe=foo"
+                             }
+                             )
 
         self.assertGreaterEqual(res.code, 400)
         self.assertIn(self._app.file_config.login_url, res.effective_url)

--- a/remoteappmanager/handlers/tests/test_user_home_handler.py
+++ b/remoteappmanager/handlers/tests/test_user_home_handler.py
@@ -1,11 +1,10 @@
-from tornado.testing import ExpectLog
+from tornado.testing import ExpectLog, AsyncHTTPTestCase
 
-from remoteappmanager.tests import utils
 from remoteappmanager.tests.mocking import dummy
 from remoteappmanager.tests.temp_mixin import TempMixin
 
 
-class TestUserHomeHandler(TempMixin, utils.AsyncHTTPTestCase, ExpectLog):
+class TestUserHomeHandler(TempMixin, AsyncHTTPTestCase, ExpectLog):
     def get_app(self):
         app = dummy.create_application()
         app.hub.verify_token.return_value = {

--- a/remoteappmanager/jupyterhub/auth/__init__.py
+++ b/remoteappmanager/jupyterhub/auth/__init__.py
@@ -1,2 +1,3 @@
 from .world_authenticator import WorldAuthenticator  # noqa
+from .basic_authenticator import BasicAuthenticator  # noqa
 from .github_whitelist_authenticator import GitHubWhitelistAuthenticator  # noqa

--- a/remoteappmanager/jupyterhub/auth/basic_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/basic_authenticator.py
@@ -1,0 +1,31 @@
+from tornado import gen
+
+from jupyterhub.auth import Authenticator
+from traitlets import Dict
+
+
+class BasicAuthenticator(Authenticator):
+    """ Simple authenticator based on a fixed set of users"""
+
+    #: Dictionary of regular username: password keys allowed
+    user_data = Dict().tag(config=True)
+
+    #: Dictionary of admin username: password keys allowed
+    admin_data = Dict().tag(config=True)
+
+    @gen.coroutine
+    def authenticate(self, handler, data):
+
+        self.log.warning(
+            'This is a basic authenticator with a fixed set '
+            'of usernames and passwords.')
+
+        username = data['username']
+
+        if username in self.admin_data:
+            if data['password'] == self.admin_data[username]:
+                return username
+
+        if username in self.user_data:
+            if data['password'] == self.user_data[username]:
+                return username

--- a/remoteappmanager/jupyterhub/auth/tests/test_basic_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_basic_authenticator.py
@@ -1,0 +1,30 @@
+from tornado.testing import AsyncTestCase, gen_test
+from unittest.mock import Mock
+
+from remoteappmanager.jupyterhub.auth import BasicAuthenticator
+
+
+class TestBasicAuthenticator(AsyncTestCase):
+
+    def setUp(self):
+        self.auth = BasicAuthenticator(
+            user_data={'foo': 'bar'},
+            admin_data={'admin': 'password'}
+        )
+        super().setUp()
+
+    @gen_test
+    def test_basic_auth(self):
+        response = yield self.auth.authenticate(
+            Mock(), {"username": "foo", "password": 'bar'})
+        self.assertEqual(response, "foo")
+
+        response = yield self.auth.authenticate(
+            Mock(), {"username": "wrong", "password": 'details'})
+        self.assertIsNone(response)
+
+    @gen_test
+    def test_admin_auth(self):
+        response = yield self.auth.authenticate(
+            Mock(), {"username": "admin", "password": 'password'})
+        self.assertEqual(response, "admin")

--- a/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_github_whitelist_authenticator.py
@@ -1,7 +1,7 @@
 import os
 
 import time
-from tornado.testing import AsyncTestCase, gen_test, LogTrapTestCase
+from tornado.testing import AsyncTestCase, gen_test, ExpectLog
 
 from remoteappmanager.tests.temp_mixin import TempMixin
 from remoteappmanager.tests.utils import mock_coro_factory
@@ -13,7 +13,7 @@ from remoteappmanager.jupyterhub.auth import GitHubWhitelistAuthenticator
 
 class TestGithubWhiteListAuthenticator(TempMixin,
                                        AsyncTestCase,
-                                       LogTrapTestCase):
+                                       ExpectLog):
     def setUp(self):
         self.auth = GitHubWhitelistAuthenticator()
         self.auth.authenticate = mock_coro_factory(return_value="foo")

--- a/remoteappmanager/jupyterhub/auth/tests/test_world_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_world_authenticator.py
@@ -1,12 +1,14 @@
-from tornado.testing import AsyncTestCase, gen_test, ExpectLog
+from tornado.testing import AsyncTestCase, ExpectLog, gen_test
 from unittest.mock import Mock
 
 from remoteappmanager.jupyterhub.auth import WorldAuthenticator
 
 
-class TestWorldAuthenticator(AsyncTestCase, ExpectLog):
+class TestWorldAuthenticator(AsyncTestCase):
     @gen_test
     def test_basic_auth(self):
         auth = WorldAuthenticator()
-        response = yield auth.authenticate(Mock(), {"username": "foo"})
-        self.assertEqual(response, "foo")
+        log_msg = 'This authenticator authenticates everyone for testing.'
+        with ExpectLog('traitlets', log_msg):
+            response = yield auth.authenticate(Mock(), {"username": "foo"})
+            self.assertEqual(response, "foo")

--- a/remoteappmanager/jupyterhub/auth/tests/test_world_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/tests/test_world_authenticator.py
@@ -1,10 +1,10 @@
-from tornado.testing import AsyncTestCase, gen_test, LogTrapTestCase
+from tornado.testing import AsyncTestCase, gen_test, ExpectLog
 from unittest.mock import Mock
 
 from remoteappmanager.jupyterhub.auth import WorldAuthenticator
 
 
-class TestWorldAuthenticator(AsyncTestCase, LogTrapTestCase):
+class TestWorldAuthenticator(AsyncTestCase, ExpectLog):
     @gen_test
     def test_basic_auth(self):
         auth = WorldAuthenticator()

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -44,10 +44,18 @@ class BaseSpawner(LocalProcessSpawner):
         for iarg, arg in enumerate(args):
             args[iarg] = arg.replace('--base-url=', '--base-urlpath=')
 
-        args.append("--proxy-api-url={}".format(self.proxy.api_server.url))
+        args.append("--proxy-api-url={}".format(
+            self.proxy.api_server.url))
+
+        args.append("--logout_url={}".format(
+            self.authenticator.logout_url(
+                self.hub.server.base_url)))
 
         if self.config_file_path:
             args.append("--config-file={}".format(self.config_file_path))
+
+        args.append("--login_service={}".format(
+            self.authenticator.login_service))
 
         return args
 

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import time
 from unittest import mock
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 
 from tornado import testing
 from jupyterhub import orm
@@ -68,7 +68,7 @@ def new_spawner(spawner_class):
     return spawner_class(db=db, user=user, hub=hub)
 
 
-class TestSystemUserSpawner(TempMixin, testing.AsyncTestCase, LogTrapTestCase):
+class TestSystemUserSpawner(TempMixin, testing.AsyncTestCase, ExpectLog):
     def setUp(self):
         super().setUp()
         self.spawner = new_spawner(SystemUserSpawner)

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -70,7 +70,8 @@ def new_spawner(spawner_class):
         return_value='/logout_test')
     authenticator.login_service = 'TEST'
 
-    return spawner_class(db=db, user=user, hub=hub, authenticator=authenticator)
+    return spawner_class(
+        db=db, user=user, hub=hub, authenticator=authenticator)
 
 
 class TestSystemUserSpawner(TempMixin, AsyncTestCase):

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -67,7 +67,8 @@ def new_spawner(spawner_class):
 
     # Mock authenticator
     authenticator = mock.Mock()
-    authenticator.logout_url = mock.Mock(return_value='/logout_test')
+    authenticator.logout_url = mock.Mock(
+        return_value='/logout_test')
     authenticator.login_service = 'TEST'
 
     return spawner_class(db=db, user=user, hub=hub, authenticator=authenticator)

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -74,7 +74,7 @@ def new_spawner(spawner_class):
     return spawner_class(db=db, user=user, hub=hub, authenticator=authenticator)
 
 
-class TestSystemUserSpawner(TempMixin, testing.AsyncTestCase, ExpectLog):
+class TestSystemUserSpawner(TempMixin, testing.AsyncTestCase):
     def setUp(self):
         super().setUp()
         self.spawner = new_spawner(SystemUserSpawner)

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -65,7 +65,12 @@ def new_spawner(spawner_class):
     # Mock hub
     hub = orm.Hub(server=generic_server)
 
-    return spawner_class(db=db, user=user, hub=hub)
+    # Mock authenticator
+    authenticator = mock.Mock()
+    authenticator.logout_url = mock.Mock(return_value='/logout_test')
+    authenticator.login_service = 'TEST'
+
+    return spawner_class(db=db, user=user, hub=hub, authenticator=authenticator)
 
 
 class TestSystemUserSpawner(TempMixin, testing.AsyncTestCase, ExpectLog):

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -5,9 +5,8 @@ import subprocess
 import sys
 import time
 from unittest import mock
-from tornado.testing import ExpectLog
 
-from tornado import testing
+from tornado.testing import AsyncTestCase
 from jupyterhub import orm
 
 from remoteappmanager.jupyterhub.spawners import (
@@ -74,7 +73,7 @@ def new_spawner(spawner_class):
     return spawner_class(db=db, user=user, hub=hub, authenticator=authenticator)
 
 
-class TestSystemUserSpawner(TempMixin, testing.AsyncTestCase):
+class TestSystemUserSpawner(TempMixin, AsyncTestCase):
     def setUp(self):
         super().setUp()
         self.spawner = new_spawner(SystemUserSpawner)

--- a/remoteappmanager/logging/tests/test_logging_mixin.py
+++ b/remoteappmanager/logging/tests/test_logging_mixin.py
@@ -1,5 +1,4 @@
-import unittest
-from unittest import mock
+from unittest import mock, TestCase
 
 from remoteappmanager.logging.logging_mixin import LoggingMixin
 
@@ -8,12 +7,13 @@ class Logged(LoggingMixin):
     pass
 
 
-class TestLoggingMixin(unittest.TestCase):
+class TestLoggingMixin(TestCase):
     def test_issue(self):
-        l = Logged()
+        logged = Logged()
         with mock.patch("tornado.log.app_log.error") as mock_error:
-            ref = l.log.issue("hello")
-            self.assertIn("hello. Ref: "+str(ref), mock_error.call_args[0][0])
-            ref = l.log.issue("hello", Exception("Boom!"))
+            ref = logged.log.issue("hello")
+            self.assertIn(
+                "hello. Ref: "+str(ref), mock_error.call_args[0][0])
+            ref = logged.log.issue("hello", Exception("Boom!"))
             self.assertIn("hello : Boom!. Ref: "+str(ref),
                           mock_error.call_args[0][0])

--- a/remoteappmanager/services/tests/test_hub.py
+++ b/remoteappmanager/services/tests/test_hub.py
@@ -1,4 +1,5 @@
-from tornado import testing, web, gen
+from tornado import web, gen
+from tornado.testing import gen_test, ExpectLog, AsyncHTTPTestCase
 from tornado.web import HTTPError
 
 from remoteappmanager.services.hub import Hub
@@ -20,7 +21,7 @@ class AuthHandler(web.RequestHandler):
         self.flush()
 
 
-class TestHub(testing.AsyncHTTPTestCase, testing.ExpectLog):
+class TestHub(AsyncHTTPTestCase):
     def get_app(self):
         self.handler = AuthHandler
         handlers = [
@@ -37,23 +38,31 @@ class TestHub(testing.AsyncHTTPTestCase, testing.ExpectLog):
         self.assertEqual(hub.api_token, api_token)
 
     def test_invalid_init(self):
-        with self.assertRaises(ValueError):
-            Hub(endpoint_url="", api_token="dummy")
+        log_msg = "Invalid endpoint url to initialise the hub connection."
+        with ExpectLog('tornado.application', log_msg):
+            with self.assertRaises(ValueError):
+                Hub(endpoint_url="", api_token="dummy")
 
-        with self.assertRaises(ValueError):
-            Hub(endpoint_url="http://fake.url/", api_token="")
+        log_msg = "Invalid API Token to initialise the hub connection."
+        with ExpectLog('tornado.application', log_msg):
+            with self.assertRaises(ValueError):
+                Hub(endpoint_url="http://fake.url/", api_token="")
 
-    @testing.gen_test
+    @gen_test
     def test_requests(self):
         endpoint_url = self.get_url("/hub")
         api_token = "whatever"
         hub = Hub(endpoint_url=endpoint_url, api_token=api_token)
 
         self.handler.ret_status = 403
-        self.assertEqual((yield hub.verify_token("foo", "bar")), {})
+        with ExpectLog('tornado.access', ''):
+            self.assertEqual(
+                (yield hub.verify_token("foo", "bar")), {})
 
         self.handler.ret_status = 501
-        self.assertEqual((yield hub.verify_token("foo", "bar")), {})
+        with ExpectLog('tornado.access', ''):
+            self.assertEqual(
+                (yield hub.verify_token("foo", "bar")), {})
 
         self.handler.ret_status = 200
         res = yield hub.verify_token("foo", "bar")

--- a/remoteappmanager/services/tests/test_hub.py
+++ b/remoteappmanager/services/tests/test_hub.py
@@ -21,7 +21,7 @@ class AuthHandler(web.RequestHandler):
         self.flush()
 
 
-class TestHub(utils.AsyncHTTPTestCase, testing.LogTrapTestCase):
+class TestHub(utils.AsyncHTTPTestCase, testing.ExpectLog):
     def get_app(self):
         self.handler = AuthHandler
         handlers = [

--- a/remoteappmanager/services/tests/test_hub.py
+++ b/remoteappmanager/services/tests/test_hub.py
@@ -1,8 +1,7 @@
 from tornado import testing, web, gen
+from tornado.web import HTTPError
 
 from remoteappmanager.services.hub import Hub
-from tornado.web import HTTPError
-from remoteappmanager.tests import utils
 
 
 class AuthHandler(web.RequestHandler):
@@ -21,7 +20,7 @@ class AuthHandler(web.RequestHandler):
         self.flush()
 
 
-class TestHub(utils.AsyncHTTPTestCase, testing.ExpectLog):
+class TestHub(testing.AsyncHTTPTestCase, testing.ExpectLog):
     def get_app(self):
         self.handler = AuthHandler
         handlers = [

--- a/remoteappmanager/services/tests/test_reverse_proxy.py
+++ b/remoteappmanager/services/tests/test_reverse_proxy.py
@@ -5,7 +5,7 @@ from remoteappmanager.services.reverse_proxy import ReverseProxy
 from tornado import gen, testing
 
 
-class TestReverseProxy(testing.AsyncTestCase, testing.LogTrapTestCase):
+class TestReverseProxy(testing.AsyncTestCase, testing.ExpectLog):
     @testing.gen_test
     def test_reverse_proxy_operations(self):
         coroutine_out = None

--- a/remoteappmanager/services/tests/test_reverse_proxy.py
+++ b/remoteappmanager/services/tests/test_reverse_proxy.py
@@ -2,11 +2,13 @@ from unittest.mock import Mock
 
 from jupyterhub import orm
 from remoteappmanager.services.reverse_proxy import ReverseProxy
-from tornado import gen, testing
+from tornado import gen
+from tornado.testing import gen_test, AsyncTestCase, ExpectLog
 
 
-class TestReverseProxy(testing.AsyncTestCase, testing.ExpectLog):
-    @testing.gen_test
+class TestReverseProxy(AsyncTestCase):
+
+    @gen_test
     def test_reverse_proxy_operations(self):
         coroutine_out = None
 
@@ -32,8 +34,14 @@ class TestReverseProxy(testing.AsyncTestCase, testing.ExpectLog):
         self.assertEqual(coroutine_out["kwargs"]["method"], "DELETE")
 
     def test_incorrect_init(self):
-        with self.assertRaises(ValueError):
-            ReverseProxy(endpoint_url="http://fake/api", api_token="")
+        log_msg = ("invalid proxy API Token to initialise the "
+                   "reverse proxy connection.")
+        with ExpectLog('tornado.application', log_msg):
+            with self.assertRaises(ValueError):
+                ReverseProxy(endpoint_url="http://fake/api", api_token="")
 
-        with self.assertRaises(ValueError):
-            ReverseProxy(endpoint_url="", api_token="foo")
+        log_msg = ("invalid proxy endpoint url to initialise the "
+                   "reverse proxy connection.")
+        with ExpectLog('tornado.application', log_msg):
+            with self.assertRaises(ValueError):
+                ReverseProxy(endpoint_url="", api_token="foo")

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -128,7 +128,7 @@ class DummyDB(interfaces.ABCDatabase):
     def list_applications(self):  # pragma: no cover
         return self.applications.values()
 
-    def grant_access(self, app_name, user_name,
+    def grant_access(self, app_name, user_name, app_license,
                      allow_home, allow_view, volume):
         app = self._get_application_id_by_name(app_name)
         user = self._get_user_id_by_name(user_name)
@@ -143,7 +143,7 @@ class DummyDB(interfaces.ABCDatabase):
 
         return id
 
-    def revoke_access(self, app_name, user_name,
+    def revoke_access(self, app_name, user_name, app_license,
                       allow_home, allow_view, volume):
         pass
 

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -134,8 +134,9 @@ class DummyDB(interfaces.ABCDatabase):
         user = self._get_user_id_by_name(user_name)
 
         source, target, mode = volume.split(':')
-        policy = DummyDBApplicationPolicy(allow_home, allow_view, False,
-                                          source, target, mode)
+        policy = DummyDBApplicationPolicy(
+            app_license, allow_home, allow_view, False,
+            source, target, mode)
 
         self.policies[len(self.policies)] = policy
         id = str(uuid.uuid4().hex)

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -77,7 +77,7 @@ class DummyDB(interfaces.ABCDatabase):
                     application_policy=policy)
                 for id, (tbl_user, application, policy)
                 in self.accounting.items()
-                if tbl_user == user]
+                if tbl_user.name == user.name]
 
     def create_user(self, user_name):  # pragma: no cover
         if user_name in [u.name for u in self.list_users()]:

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -17,7 +17,7 @@ class DummyDB:
 
 class TestApplication(TempMixin,
                       testing.AsyncTestCase,
-                      testing.LogTrapTestCase):
+                      testing.ExpectLog):
     def setUp(self):
         super().setUp()
 

--- a/remoteappmanager/tests/test_netutils.py
+++ b/remoteappmanager/tests/test_netutils.py
@@ -1,6 +1,6 @@
 from unittest import mock
 from tornado import web
-from tornado.testing import AsyncHTTPTestCase, gen_test, LogTrapTestCase
+from tornado.testing import AsyncHTTPTestCase, gen_test, ExpectLog
 
 from remoteappmanager.tests.utils import mock_coro_new_callable
 from remoteappmanager.netutils import wait_for_http_server_2xx
@@ -23,7 +23,7 @@ class LongHandler(ShortHandler):
     error_count = 100000
 
 
-class TestUtils(AsyncHTTPTestCase, LogTrapTestCase):
+class TestUtils(AsyncHTTPTestCase, ExpectLog):
     def get_app(self):
 
         app = web.Application(handlers=[('/short', ShortHandler),

--- a/remoteappmanager/tests/test_user.py
+++ b/remoteappmanager/tests/test_user.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from ..user import User
+
+
+class TestUser(TestCase):
+
+    def setUp(self):
+
+        self.user = User()
+
+    def test_demo_applications(self):
+
+        self.assertListEqual([], self.user.demo_applications)
+        self.assertListEqual(
+            [],
+            self.user.demo_applications
+        )

--- a/remoteappmanager/tests/test_user.py
+++ b/remoteappmanager/tests/test_user.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ..user import User
+from remoteappmanager.user import User
 
 
 class TestUser(TestCase):

--- a/remoteappmanager/tests/test_utils.py
+++ b/remoteappmanager/tests/test_utils.py
@@ -1,8 +1,10 @@
-from tornado.testing import LogTrapTestCase
+from unittest import TestCase
+
+from tornado.testing import ExpectLog
 from remoteappmanager import utils
 
 
-class TestUtils(LogTrapTestCase):
+class TestUtils(ExpectLog, TestCase):
     def test_parse_volume_string(self):
         self.assertEqual(utils.parse_volume_string("/foo:/bar:ro"),
                          ("/foo", "/bar", "ro"))

--- a/remoteappmanager/tests/test_utils.py
+++ b/remoteappmanager/tests/test_utils.py
@@ -1,10 +1,9 @@
 from unittest import TestCase
 
-from tornado.testing import ExpectLog
 from remoteappmanager import utils
 
 
-class TestUtils(ExpectLog, TestCase):
+class TestUtils(TestCase):
     def test_parse_volume_string(self):
         self.assertEqual(utils.parse_volume_string("/foo:/bar:ro"),
                          ("/foo", "/bar", "ro"))

--- a/remoteappmanager/tests/utils.py
+++ b/remoteappmanager/tests/utils.py
@@ -1,9 +1,6 @@
 import contextlib
 import sys
-import socket
 
-import tornado.netutil
-import tornado.testing
 from tornado import gen
 
 from remoteappmanager.command_line_config import CommandLineConfig
@@ -68,35 +65,6 @@ def invocation_argv():
     yield
 
     sys.argv[:] = saved_argv
-
-
-# Workaround for tornado bug #1573, already fixed in master, but not yet
-# available. Remove when upgrading tornado.
-def bind_unused_port(reuse_port=False):
-    """Binds a server socket to an available port on localhost.
-
-    Returns a tuple (socket, port).
-    """
-    sock = tornado.netutil.bind_sockets(None,
-                                        '127.0.0.1',
-                                        family=socket.AF_INET,
-                                        reuse_port=reuse_port)[0]
-    port = sock.getsockname()[1]
-    return sock, port
-
-
-class AsyncHTTPTestCase(tornado.testing.AsyncHTTPTestCase):
-    """Base class workaround for the above condition."""
-    def setUp(self):
-        self._bind_unused_port_orig = tornado.testing.bind_unused_port
-        tornado.testing.bind_unused_port = bind_unused_port
-
-        def cleanup():
-            tornado.testing.bind_unused_port = self._bind_unused_port_orig
-
-        self.addCleanup(cleanup)
-
-        super().setUp()
 
 
 def mock_coro_new_callable(return_value=None, side_effect=None):

--- a/remoteappmanager/tests/webapi_test_case.py
+++ b/remoteappmanager/tests/webapi_test_case.py
@@ -1,7 +1,5 @@
 from tornado import escape
-from tornado.testing import ExpectLog
-
-from .utils import AsyncHTTPTestCase
+from tornado.testing import ExpectLog, AsyncHTTPTestCase
 
 
 class WebAPITestCase(AsyncHTTPTestCase, ExpectLog):

--- a/remoteappmanager/tests/webapi_test_case.py
+++ b/remoteappmanager/tests/webapi_test_case.py
@@ -1,10 +1,10 @@
 from tornado import escape
-from tornado.testing import LogTrapTestCase
+from tornado.testing import ExpectLog
 
 from .utils import AsyncHTTPTestCase
 
 
-class WebAPITestCase(AsyncHTTPTestCase, LogTrapTestCase):
+class WebAPITestCase(AsyncHTTPTestCase, ExpectLog):
     """Base class for tests accessing the Web API,
     providing basic methods to issue web requests, get results, and compare
     against the expected HTTP code.

--- a/remoteappmanager/tests/webapi_test_case.py
+++ b/remoteappmanager/tests/webapi_test_case.py
@@ -1,8 +1,8 @@
 from tornado import escape
-from tornado.testing import ExpectLog, AsyncHTTPTestCase
+from tornado.testing import AsyncHTTPTestCase
 
 
-class WebAPITestCase(AsyncHTTPTestCase, ExpectLog):
+class WebAPITestCase(AsyncHTTPTestCase):
     """Base class for tests accessing the Web API,
     providing basic methods to issue web requests, get results, and compare
     against the expected HTTP code.

--- a/remoteappmanager/user.py
+++ b/remoteappmanager/user.py
@@ -10,3 +10,12 @@ class User(HasTraits):
 
     #: Can be none if the username cannot be found in the database.
     account = Any()
+
+    #: Reference to the authenticator method used for user login
+    login_service = Unicode()
+
+    @property
+    def demo_applications(self):
+        """Can be implemented to provide any default applications
+        granted by the user"""
+        return []

--- a/remoteappmanager/webapi/admin/accounting.py
+++ b/remoteappmanager/webapi/admin/accounting.py
@@ -15,7 +15,7 @@ from remoteappmanager.db import exceptions as db_exceptions
 class Accounting(Resource):
     user_id = Unicode(allow_empty=False, strip=True)
     image_name = Unicode(allow_empty=False, strip=True)
-    app_license = Unicode(allow_empty=True, strip=True)
+    app_license = Unicode(allow_none=True)
     allow_home = Bool()
     volume_source = Unicode(allow_none=True)
     volume_target = Unicode(allow_none=True)

--- a/remoteappmanager/webapi/admin/accounting.py
+++ b/remoteappmanager/webapi/admin/accounting.py
@@ -15,6 +15,7 @@ from remoteappmanager.db import exceptions as db_exceptions
 class Accounting(Resource):
     user_id = Unicode(allow_empty=False, strip=True)
     image_name = Unicode(allow_empty=False, strip=True)
+    app_license = Unicode(allow_empty=True, strip=True)
     allow_home = Bool()
     volume_source = Unicode(allow_none=True)
     volume_target = Unicode(allow_none=True)
@@ -47,6 +48,7 @@ class AccountingHandler(ResourceHandler):
             id = db.grant_access(
                 resource.image_name,
                 acc_user.name,
+                resource.app_license,
                 resource.allow_home,
                 True,
                 volume,
@@ -91,6 +93,7 @@ class AccountingHandler(ResourceHandler):
                     identifier=str(acc.id),
                     user_id=str(acc_user.id),
                     image_name=acc.application.image,
+                    app_license=acc.application_policy.app_license,
                     allow_home=acc.application_policy.allow_home,
                     volume_source=acc.application_policy.volume_source,
                     volume_target=acc.application_policy.volume_target,

--- a/remoteappmanager/webapi/admin/tests/test_accounting.py
+++ b/remoteappmanager/webapi/admin/tests/test_accounting.py
@@ -45,6 +45,7 @@ class TestAccounting(WebAPITestCase):
         self.post("/user/johndoe/api/v1/accounting/",
                   {"user_id": "0",
                    "image_name": "image_id1",
+                   "app_license": "",
                    "allow_home": True,
                    "volume_source": "/foo",
                    "volume_target": "/bar",
@@ -56,6 +57,7 @@ class TestAccounting(WebAPITestCase):
         self.post("/user/johndoe/api/v1/accounting/",
                   {"user_id": "0",
                    "image_name": "image_id1",
+                   "app_license": "",
                    "allow_home": True,
                    "volume_source": "/foo",
                    "volume_target": "/bar",
@@ -71,6 +73,7 @@ class TestAccounting(WebAPITestCase):
             self.post("/user/johndoe/api/v1/accounting/",
                       {"user_id": "0",
                        "image_name": "image_id1",
+                       "app_license": "",
                        "allow_home": True,
                        "volume_source": "/foo",
                        "volume_target": "/bar",
@@ -82,6 +85,7 @@ class TestAccounting(WebAPITestCase):
         self.post("/user/johndoe/api/v1/accounting/",
                   {"user_id": "234",
                    "image_name": "image_id1",
+                   "app_license": "",
                    "allow_home": True,
                    "volume_source": "/foo",
                    "volume_target": "/bar",
@@ -97,13 +101,14 @@ class TestAccounting(WebAPITestCase):
             self.post("/user/johndoe/api/v1/accounting/",
                       {"user_id": "0",
                        "image_name": "image_id1",
+                       "app_license": "",
                        "allow_home": True,
                        "volume_source": "",
                        "volume_target": "",
                        "volume_mode": ""
                        },
                       httpstatus.CREATED)
-            self.assertEqual(mock_grant_access.call_args[0][4], None)
+            self.assertEqual(mock_grant_access.call_args[0][5], None)
 
     def test_items(self):
         self.get("/user/johndoe/api/v1/accounting/", httpstatus.BAD_REQUEST)

--- a/remoteappmanager/webapi/application.py
+++ b/remoteappmanager/webapi/application.py
@@ -15,6 +15,7 @@ class Container(ResourceFragment):
 
 
 class Policy(ResourceFragment):
+    app_license = Unicode(allow_none=True)
     allow_home = Bool()
     volume_source = Unicode(allow_none=True)
     volume_target = Unicode(allow_none=True)
@@ -44,7 +45,7 @@ class ApplicationHandler(ResourceHandler):
     @authenticated
     def retrieve(self, resource, **kwargs):
         accs = self.application.db.get_accounting_for_user(
-            self.current_user.account
+            self.current_user
         )
         identifier = resource.identifier
 
@@ -94,7 +95,7 @@ class ApplicationHandler(ResourceHandler):
         """Retrieves a dictionary containing the image and the associated
         container, if active, as values."""
         accs = self.application.db.get_accounting_for_user(
-            self.current_user.account)
+            self.current_user)
 
         result = []
         for entry in accs:

--- a/remoteappmanager/webapi/container.py
+++ b/remoteappmanager/webapi/container.py
@@ -30,8 +30,7 @@ class ContainerHandler(ResourceHandler):
         mapping_id = resource.mapping_id
 
         webapp = self.application
-        account = self.current_user.account
-        accountings = webapp.db.get_accounting_for_user(account)
+        accountings = webapp.db.get_accounting_for_user(self.current_user)
         container_manager = webapp.container_manager
 
         choice = [(accounting.id,
@@ -147,7 +146,7 @@ class ContainerHandler(ResourceHandler):
         container_manager = self.application.container_manager
 
         accountings = self.application.db.get_accounting_for_user(
-            self.current_user.account)
+            self.current_user)
 
         running_containers = []
 
@@ -242,6 +241,8 @@ class ContainerHandler(ResourceHandler):
                                  home_path, user_name)
                 pass
 
+        if policy.app_license:
+            environment['APP_LICENSE'] = policy.app_license
         if None not in volume_spec:
             volume_source, volume_target, volume_mode = volume_spec
             volumes[volume_source] = {'bind': volume_target,

--- a/remoteappmanager/webapi/tests/test_application.py
+++ b/remoteappmanager/webapi/tests/test_application.py
@@ -47,6 +47,7 @@ class TestApplication(WebAPITestCase):
         application_mock_2.image = "hello2"
 
         policy = Mock(
+            app_license='',
             allow_home=True,
             volume_source="foo",
             volume_target="bar",
@@ -72,6 +73,7 @@ class TestApplication(WebAPITestCase):
                 'two': {
                     'image': {
                         'policy': {
+                            'app_license': '',
                             'volume_mode': 'ro',
                             'volume_source': 'foo',
                             'allow_home': True,
@@ -89,6 +91,7 @@ class TestApplication(WebAPITestCase):
                 'one': {
                     'image': {
                         'policy': {
+                            'app_license': '',
                             'volume_mode': 'ro',
                             'volume_source': 'foo',
                             'allow_home': True,
@@ -136,6 +139,7 @@ class TestApplication(WebAPITestCase):
                                  'icon_128': '',
                                  'name': 'boo',
                                  'policy': {
+                                     'app_license': '',
                                      "allow_home": True,
                                      "volume_mode": 'ro',
                                      "volume_source": "foo",
@@ -166,6 +170,7 @@ class TestApplication(WebAPITestCase):
                                  'name': 'boo',
                                  'ui_name': 'foo_ui',
                                  'policy': {
+                                     'app_license': '',
                                      "allow_home": True,
                                      "volume_mode": 'ro',
                                      "volume_source": "foo",

--- a/remoteappmanager/webapi/tests/test_container.py
+++ b/remoteappmanager/webapi/tests/test_container.py
@@ -80,9 +80,9 @@ class TestContainer(WebAPITestCase):
                    new_callable=mock_coro_new_callable()):
 
             manager = self._app.container_manager
-            manager.start_container = mock_coro_factory(DockerContainer(
-                url_id="3456"
-            ))
+            manager.start_container = mock_coro_factory(
+                return_value=DockerContainer(url_id="3456")
+            )
             self.post(
                 "/user/johndoe/api/v1/containers/",
                 dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,16 @@
 setuptools==21.0
-tornado==4.3
+tornado==5.1.1
 # Fix to 2.10.0 due to docker-py needs (fails with 2.11.1)
 requests==2.10.0
 # We want 1.8 because 1.10 uses API version 1.24 and the docker server
 # on ubuntu uses 1.23, so they don't like each other.
 docker-py==1.8
 escapism==0.0.1
-git+git://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub
+# Pinned to 0.8.0.dev0 due to issues with spawners (fails with 0.8.0)
+git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5
-git+git://github.com/simphony/tornado-webapi.git@13d044331a1e86a03b18f6c1424cc9adf424ddac#egg=tornadowebapi
-oauthenticator==0.5.1
+git+http://github.com/simphony/tornado-webapi.git@8b6846faae23657a04cf97ca5229ce8ea083d000#egg=tornadowebapi
+# Pinned to 0.10.0 since 0.11.0 does not seem to be compatible with jupyterhub 0.7.x
+oauthenticator==0.10.0

--- a/scripts/generate_certificate.sh
+++ b/scripts/generate_certificate.sh
@@ -2,14 +2,51 @@
 # Use this script to generate a self-signed certificate for jupyterhub.
 # Normally needed only when we deploy an experimental installation for the
 # first time.
-if test -e test.crt
-then
-    echo "Certificate already present, skipping. Delete the current certificate to recreate."
-    exit 0
-fi
 
-openssl genrsa -out test.key 1024
-openssl req -new -key test.key -out test.csr -batch
-cp test.key test.key.org
-openssl rsa -in test.key.org -out test.key
-openssl x509 -req -days 365 -in test.csr -signkey test.key -out test.crt
+type=$1
+simphony_remote=$2
+
+if [ $type = 'test' ]
+then
+
+  directory=${simphony_remote}/jupyterhub
+
+  if test -e ${directory}/test.crt
+  then
+      echo "Certificate already present, skipping. Delete the current certificate to recreate."
+      exit 0
+  fi
+
+  echo "Generating self-signed certificates in $directory"
+
+  openssl genrsa -out ${directory}/test.key 1024
+  openssl req -new -key ${directory}/test.key -out ${directory}/test.csr -batch
+  cp ${directory}/test.key ${directory}/test.key.org
+  openssl rsa -in ${directory}/test.key.org -out ${directory}/test.key
+  openssl x509 -req -days 365 -in ${directory}/test.csr -signkey ${directory}/test.key -out ${directory}/test.crt
+
+elif [ $type = 'nginx' ]
+then
+
+  directory=${simphony_remote}/nginx/certs
+
+  if [ ! -d $directory ]; then \
+		mkdir $directory
+	fi
+
+  if test -e ${directory}/nginx-selfsigned.crt
+  then
+      echo "Certificate already present, skipping. Delete the current certificate to recreate."
+      exit 0
+  fi
+
+  echo "Generating Nginx certificates."
+
+  openssl req -x509 -nodes -days 365 \
+    -newkey rsa:2048 \
+    -keyout ${directory}/nginx-selfsigned.key \
+    -out ${directory}/nginx-selfsigned.crt
+
+  openssl dhparam -out ${directory}/dhparam.pem 2048 # Use 4096 for production deployment
+
+fi

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -31,16 +31,16 @@ class RemoteAppDriverTest(unittest.TestCase):
         self.verificationErrors = []
         self.accept_next_alert = True
 
-        permissions_db_path = os.path.join(ff_profile.profile_dir,
-                                           "permissions.sqlite")
-
-        with contextlib.closing(sqlite3.connect(permissions_db_path)) as db:
-            cur = db.cursor()
-            cur.execute(
-                ("INSERT INTO 'moz_perms' VALUES (1, '{base_url}', "
-                 "'popup', 1, 0, 0, 1474977124357)").format(
-                    base_url=self.base_url))
-            db.commit()
+        # permissions_db_path = os.path.join(ff_profile.profile_dir,
+        #                                    "permissions.sqlite")
+        #
+        # with contextlib.closing(sqlite3.connect(permissions_db_path)) as db:
+        #     cur = db.cursor()
+        #     cur.execute(
+        #         ("INSERT INTO 'moz_perms' VALUES (1, '{base_url}', "
+        #          "'popup', 1, 0, 0, 1474977124357)").format(
+        #             base_url=self.base_url))
+        #     db.commit()
 
     def wait_until_presence_of_element_located(self, how, what):
         """ Wait until a located element is present

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -31,17 +31,6 @@ class RemoteAppDriverTest(unittest.TestCase):
         self.verificationErrors = []
         self.accept_next_alert = True
 
-        # permissions_db_path = os.path.join(ff_profile.profile_dir,
-        #                                    "permissions.sqlite")
-        #
-        # with contextlib.closing(sqlite3.connect(permissions_db_path)) as db:
-        #     cur = db.cursor()
-        #     cur.execute(
-        #         ("INSERT INTO 'moz_perms' VALUES (1, '{base_url}', "
-        #          "'popup', 1, 0, 0, 1474977124357)").format(
-        #             base_url=self.base_url))
-        #     db.commit()
-
     def wait_until_presence_of_element_located(self, how, what):
         """ Wait until a located element is present
         Parameters

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -37,7 +37,7 @@ class RemoteAppDriverTest(unittest.TestCase):
         with contextlib.closing(sqlite3.connect(permissions_db_path)) as db:
             cur = db.cursor()
             cur.execute(
-                ("INSERT INTO moz_hosts VALUES (1, '{base_url}', "
+                ("INSERT INTO moz_perms VALUES (1, '{base_url}', "
                  "'popup', 1, 0, 0, 1474977124357)").format(
                     base_url=self.base_url))
             db.commit()

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -37,7 +37,7 @@ class RemoteAppDriverTest(unittest.TestCase):
         with contextlib.closing(sqlite3.connect(permissions_db_path)) as db:
             cur = db.cursor()
             cur.execute(
-                ("INSERT INTO moz_perms VALUES (1, '{base_url}', "
+                ("INSERT INTO moz_hosts VALUES (1, '{base_url}', "
                  "'popup', 1, 0, 0, 1474977124357)").format(
                     base_url=self.base_url))
             db.commit()

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -17,6 +17,7 @@ class RemoteAppDriverTest(unittest.TestCase):
     def setUp(self):
         ff_binary = webdriver.firefox.firefox_binary.FirefoxBinary()
         ff_profile = webdriver.firefox.firefox_profile.FirefoxProfile()
+        ff_profile.set_preference("dom.webnotifications.enabled", False)
         ff_profile.assume_untrusted_cert_issuer = True
         ff_profile.accept_untrusted_certs = True
         capabilities = webdriver.DesiredCapabilities().FIREFOX

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -37,7 +37,7 @@ class RemoteAppDriverTest(unittest.TestCase):
         with contextlib.closing(sqlite3.connect(permissions_db_path)) as db:
             cur = db.cursor()
             cur.execute(
-                ("INSERT INTO moz_perms VALUES (1, '{base_url}', "
+                ("INSERT INTO 'moz_perms' VALUES (1, '{base_url}', "
                  "'popup', 1, 0, 0, 1474977124357)").format(
                     base_url=self.base_url))
             db.commit()

--- a/selenium_tests/test_user_accounting.py
+++ b/selenium_tests/test_user_accounting.py
@@ -19,18 +19,12 @@ class TestUserAccounting(AdminDriverTest):
         self.wait_until_invisibility_of_element_located(
             By.CSS_SELECTOR, ".modal-fade-leave-to")
 
-        # FIXME: This test is currently broken, since it will report that the
-        #  "Remove" button is obstructed in the browser (although it is not in
-        #  the deployment). It seems to be a selenium issue, which may have been
-        #  previously suppressed by disallowing popups in the Firefox profile
-        #  permissions.sqlite file. However there is no obvious way to access
-        #  this file any more with later versions of Firefox (> 75.0)
         # Click remove button
-        # self.click_row_action_button("mrenou", "Remove")
-        #
-        # self.click_modal_footer_button("Ok")
-        #
-        # self.wait_until_invisibility_of_row("mrenou")
+        self.click_row_action_button("mrenou", "Remove")
+
+        self.click_modal_footer_button("Ok")
+
+        self.wait_until_invisibility_of_row("mrenou")
 
     def test_admin_name_header_bug(self):
         self.click_first_element_located(By.LINK_TEXT, "Users")

--- a/selenium_tests/test_user_accounting.py
+++ b/selenium_tests/test_user_accounting.py
@@ -17,12 +17,18 @@ class TestUserAccounting(AdminDriverTest):
         self.type_text_in_element_located(By.CSS_SELECTOR, ".modal-body > form > div > input", "mrenou")
         self.click_modal_footer_button("Submit")
 
+        # FIXME: This test is currently broken, since it will report that the
+        #  "Remove" button is obstructed in the browser (although it is not in
+        #  the deployment). It seems to be a selenium issue, which may have been
+        #  previously suppressed by disallowing popups in the Firefox profile
+        #  permissions.sqlite file. However there is no obvious way to access
+        #  this file any more with later versions of Firefox (> 75.0)
         # Click remove button
-        self.click_row_action_button("mrenou", "Remove")
-
-        self.click_modal_footer_button("Ok")
-
-        self.wait_until_invisibility_of_row("mrenou")
+        # self.click_row_action_button("mrenou", "Remove")
+        #
+        # self.click_modal_footer_button("Ok")
+        #
+        # self.wait_until_invisibility_of_row("mrenou")
 
     def test_admin_name_header_bug(self):
         self.click_first_element_located(By.LINK_TEXT, "Users")

--- a/selenium_tests/test_user_accounting.py
+++ b/selenium_tests/test_user_accounting.py
@@ -16,6 +16,8 @@ class TestUserAccounting(AdminDriverTest):
         self.click_first_button("Create New Entry")
         self.type_text_in_element_located(By.CSS_SELECTOR, ".modal-body > form > div > input", "mrenou")
         self.click_modal_footer_button("Submit")
+        self.wait_until_invisibility_of_element_located(
+            By.CSS_SELECTOR, ".modal-fade-leave-to")
 
         # FIXME: This test is currently broken, since it will report that the
         #  "Remove" button is obstructed in the browser (although it is not in

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install as _install
 
 # Setup version
-VERSION = '2.1.0'
+VERSION = '2.2.0.dev'
 
 # Read description
 with open('README.rst', 'r') as readme:


### PR DESCRIPTION
This PR updates the repository with developments from the Simphony-3 group.

### New features:
- Inclusion of (optional) license key in `ApplicationPolicy` object
- Inclusion of Nginx template scripts for setting up a reverse proxy
- Inclusion of `BasicAuthenticator` class for simple demo deployments
- Supports additional OAuth services using `oauthenticator` package

### Updates:
- Updated Makefile with supported Ubuntu 18.0.4 and CentOS7 build
- Updated `tornado` package to version 5.1.1
- Updated dependency versions (now install `astor` through PyPi)
- Updated documentation

### Removals
- Replace deprecated `tornado.testing.LogTrapTestCase` test case class with `ExpectLog`
- Remove `AsyncTestCase` patch for older versions of `tornado.testing`

### Maintenance
- Docker compose scripts included to build SR docker image for debug purposes
- Included `geckodriver` installation for selenium testing
- TravisCI build now uses Ubuntu 18.04 and Firefox 75.0