### PR TITLE
Add build matrix with CentOS to GH Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: Install make on Ubuntu
         if: ${{ matrix.container == 'ubuntu:18.04' }}
-        run: apt-get install build-essential
+        run: |
+        apt-get update -y
+        apt-get install -y build-essential
 
       - name: Install requirements
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install make on Ubuntu
+        if: ${{ matrix.container == 'ubuntu:18.04' }}
+        run: sudo apt-get install build-essential
+
       - name: Install requirements
         run: |
           make deps

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,14 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        container:
+          - 'ubuntu:18.04'
+          - 'centos:7'
+
     runs-on: ubuntu-18.04
+    container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
           - 'ubuntu:18.04'
           - 'centos:7'
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container: ${{ matrix.container }}
 
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install make on Ubuntu
         if: ${{ matrix.container == 'ubuntu:18.04' }}
-        run: sudo apt-get install build-essential
+        run: apt-get install build-essential
 
       - name: Install requirements
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,14 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Firefox
-        uses: browser-actions/setup-firefox@latest
-        with:
-          firefox-version: "75.0"
-
-      - name: Before Install
+      - name: Install requirements
         run: |
-          firefox --version
           make deps
           make venv
           . venv/bin/activate
@@ -38,20 +32,30 @@ jobs:
           python -c "import setuptools; print(setuptools.__version__)"
           pip --version
 
-      - name: Install
+      - name: Install Firefox
+        uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: "75.0"
+      - run: firefox --version
+
+      - name: Install Simphony-Remote
         run: |
           . venv/bin/activate
           make install
 
-      - name: Before Test
+      - name: Install development requirements
         run: |
           . venv/bin/activate
           make devdeps
 
-      - name: Test
+      - name: Flake8 checks
         run: |
           . venv/bin/activate
           flake8 .
+
+      - name: Test
+        run: |
+          . venv/bin/activate
           make pythontest
           make jstest
           make docs
@@ -68,7 +72,7 @@ jobs:
           sleep 3
           DISPLAY=:99 python -m unittest discover -s selenium_tests -t . -v
 
-      - name: After Success
+      - name: Coverage
         run: |
           pushd jupyterhub
           `pwd`/start.sh &

--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build_centos:
+    # GitHub Actions does not currently support CentOS as an official platform, so in order to
+    # test on this OS we need to run it as a container based on the Ubuntu environment
     runs-on: ubuntu-latest
 
     strategy:
@@ -55,3 +57,10 @@ jobs:
         run: |
           . venv/bin/activate
           make devdeps
+
+      - name: Test python backend
+        run: |
+          . venv/bin/activate
+          export LC_ALL=en_US.UTF-8
+          export LANG=en_US.UTF-8
+          make pythontest

--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build_centos:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        container: ["centos:7"]
+
+    container:
+      image: ${{ matrix.container }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install make and sudo
+        run: |
+          yum update -y
+          yum install -y sudo
+          yum groupinstall -y "Development Tools"
+          yum install -y  gtk3 libXext libXrender libXtst libX11 libXau libXcursor libXdmcp libXfixes libXi libXmu libXp libXpm libXt
+
+      - name: Install requirements
+        run: |
+          make deps
+          make venv
+          . venv/bin/activate
+          export PATH=`npm bin`:$PATH
+          make pythondeps
+          python -c "import setuptools; print(setuptools.__version__)"
+          pip --version
+
+      - name: Install Firefox
+        run: |
+          cd /usr/local
+          curl -O http://ftp.mozilla.org/pub/firefox/releases/75.0/linux-x86_64/en-US/firefox-75.0.tar.bz2
+          tar xvjf firefox-75.0.tar.bz2
+          sudo ln -s /usr/local/firefox/firefox /usr/bin/firefox
+
+      - name: Install Simphony-Remote
+        run: |
+          . venv/bin/activate
+          make install
+
+      - name: Install development requirements
+        run: |
+          . venv/bin/activate
+          make devdeps

--- a/.github/workflows/build_test_ubuntu18.yml
+++ b/.github/workflows/build_test_ubuntu18.yml
@@ -45,12 +45,16 @@ jobs:
           . venv/bin/activate
           flake8 .
 
+      - name: Build docs
+        run: |
+          . venv/bin/activate
+          make docs
+
       - name: Test
         run: |
           . venv/bin/activate
           make pythontest
           make jstest
-          make docs
           make testimages
           make testdb
           make certs

--- a/.github/workflows/build_test_ubuntu18.yml
+++ b/.github/workflows/build_test_ubuntu18.yml
@@ -9,24 +9,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        container:
-          - 'ubuntu:18.04'
-          - 'centos:7'
-
-    runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+  build_test_ubuntu:
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install make on Ubuntu
-        if: ${{ matrix.container == 'ubuntu:18.04' }}
-        run: |
-        apt-get update -y
-        apt-get install -y build-essential
 
       - name: Install requirements
         run: |
@@ -42,7 +29,6 @@ jobs:
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: "75.0"
-      - run: firefox --version
 
       - name: Install Simphony-Remote
         run: |

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,16 @@ devdeps:
 	@echo "Installing test dependencies"
 	@echo "----------------------------"
 	pip3 -q install -r dev-requirements.txt -r doc-requirements.txt
-	sudo apt-get -qq install phantomjs
+	if [ -f "/etc/lsb-release" ]; then \
+		sudo apt-get -qq install phantomjs; \
+	elif [ -f "/etc/centos-release" ]; then \
+		curl -O https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2; \
+		tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share; \
+		sudo ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin; \
+	fi
 
 	# Install geckodriver (for selenium testing)
-	wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
+	curl -L -O https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz
 	sudo sh -c 'tar -x geckodriver -zf geckodriver-v0.26.0-linux64.tar.gz -O > /usr/bin/geckodriver'
 	sudo chmod +x /usr/bin/geckodriver
 	rm geckodriver-v0.26.0-linux64.tar.gz


### PR DESCRIPTION
Closes #557 

This PR adds a second workflow that targets CentOS 7, only installing Symphony Remote on this platform. Tests are run separately in the Ubuntu workflow. 