### PR TITLE
Extend remoteapprest to add startupdata option

### DIFF
--- a/remoteappmanager/cli/remoteapprest/__main__.py
+++ b/remoteappmanager/cli/remoteapprest/__main__.py
@@ -152,8 +152,20 @@ def start(ctx, identifier, startupdata):
 
     payload_dict = dict(mapping_id=identifier)
     if startupdata is not None:
-        payload_dict.update(
-            configurables=dict(startupdata=dict(startupdata=startupdata)))
+        # First make sure that the allow_startup_data policy is True
+        request_url = urljoin(url,
+                              "/user/{}/api/v1/applications/".format(username))
+        response = requests.get(request_url, cookies=cookies, verify=False)
+        apps_data = json.loads(response.content.decode("utf-8"))
+        app_data = apps_data["items"][identifier]
+        allow_startup_data = app_data["image"]["policy"]["allow_startup_data"]
+        if allow_startup_data:
+            payload_dict.update(
+                configurables=dict(startupdata=dict(startupdata=startupdata)))
+        else:
+            raise click.ClickException(
+                "The 'allow_startup_data' policy is False for the current "
+                "user.\nExiting.")
 
     payload = json.dumps(payload_dict)
 

--- a/remoteappmanager/cli/remoteapprest/__main__.py
+++ b/remoteappmanager/cli/remoteapprest/__main__.py
@@ -137,9 +137,12 @@ def available(ctx):
 
 @app.command()
 @click.argument("identifier")
+@click.option("--startupdata", default=None)
 @click.pass_context
-def start(ctx, identifier):
+def start(ctx, identifier, startupdata):
     """Starts a container for application identified by IDENTIFIER.
+    If ``startupdata`` is provided, the container will open the given file at
+    startup.
     If a container is already running, restarts it."""
     cred = ctx.obj.credentials
     url, username, cookies = cred.url, cred.username, cred.cookies
@@ -147,9 +150,12 @@ def start(ctx, identifier):
     request_url = urljoin(url,
                           "/user/{}/api/v1/containers/".format(username))
 
-    payload = json.dumps(dict(
-        mapping_id=identifier
-    ))
+    payload_dict = dict(mapping_id=identifier)
+    if startupdata is not None:
+        payload_dict.update(
+            configurables=dict(startupdata=dict(startupdata=startupdata)))
+
+    payload = json.dumps(payload_dict)
 
     response = requests.post(request_url, payload, cookies=cookies,
                              verify=False)

--- a/remoteappmanager/cli/remoteapprest/__main__.py
+++ b/remoteappmanager/cli/remoteapprest/__main__.py
@@ -153,9 +153,9 @@ def start(ctx, identifier, startupdata):
     payload_dict = dict(mapping_id=identifier)
     if startupdata is not None:
         # First make sure that the allow_startup_data policy is True
-        request_url = urljoin(url,
-                              "/user/{}/api/v1/applications/".format(username))
-        response = requests.get(request_url, cookies=cookies, verify=False)
+        check_url = urljoin(url,
+                            "/user/{}/api/v1/applications/".format(username))
+        response = requests.get(check_url, cookies=cookies, verify=False)
         apps_data = json.loads(response.content.decode("utf-8"))
         app_data = apps_data["items"][identifier]
         allow_startup_data = app_data["image"]["policy"]["allow_startup_data"]

--- a/remoteappmanager/cli/tests/test_remoteapprest.py
+++ b/remoteappmanager/cli/tests/test_remoteapprest.py
@@ -130,10 +130,20 @@ class TestRemoteAppREST(TempMixin, unittest.TestCase):
 
     def test_app_start(self):
         with mock.patch('requests.post') as mock_post, \
+                mock.patch("requests.get") as mock_get, \
                 mock.patch("remoteappmanager.cli.remoteapprest.__main__."
                            "Credentials.from_file") as mock_from_file:
 
             mock_from_file.return_value = self.get_mock_credentials()
+
+            response = [mock.Mock()]
+            response[0].content = json.dumps(
+                {'items': {'1': {"image": {
+                    "policy": {"allow_startup_data": True}
+                }}}}
+            ).encode("utf-8")
+
+            mock_get.side_effect = response
 
             self._remoteapprest("app start 1")
             self.assertEqual(mock_post.call_args[0][0],

--- a/remoteappmanager/cli/tests/test_remoteapprest.py
+++ b/remoteappmanager/cli/tests/test_remoteapprest.py
@@ -141,6 +141,18 @@ class TestRemoteAppREST(TempMixin, unittest.TestCase):
             self.assertEqual(mock_post.call_args[0][1],
                              json.dumps({"mapping_id": "1"}))
 
+            self._remoteapprest("app start 1 --startupdata=/test")
+            self.assertEqual(mock_post.call_args[0][0],
+                             "/user/bar/api/v1/containers/")
+            self.assertEqual(
+                mock_post.call_args[0][1],
+                json.dumps(
+                    {"mapping_id": "1",
+                     "configurables": {
+                         "startupdata": {"startupdata": "/test"}
+                     }}
+                ))
+
     def test_app_stop(self):
         with mock.patch('requests.delete') as mock_delete, \
                 mock.patch("remoteappmanager.cli.remoteapprest.__main__."

--- a/remoteappmanager/cli/tests/test_remoteapprest.py
+++ b/remoteappmanager/cli/tests/test_remoteapprest.py
@@ -153,6 +153,64 @@ class TestRemoteAppREST(TempMixin, unittest.TestCase):
                      }}
                 ))
 
+    def test_app_start_allow_startup_data(self):
+        with mock.patch("requests.get") as mock_get, \
+                mock.patch("remoteappmanager.cli.remoteapprest.__main__."
+                           "Credentials.from_file") as mock_from_file:
+
+            mock_from_file.return_value = self.get_mock_credentials()
+
+            # allow_startup_data is False, so this will fail
+
+            response = [mock.Mock()]
+            response[0].content = json.dumps(
+                {'items': {'1': {"image": {
+                    "policy": {"allow_startup_data": False}
+                }}}}
+            ).encode("utf-8")
+
+            mock_get.side_effect = response
+
+            argstring = "app start 1 --startupdata=/test"
+            runner = CliRunner()
+            result = runner.invoke(remoteapprest.cli,
+                                   argstring.split(),
+                                   catch_exceptions=True)
+
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("The 'allow_startup_data' policy is False for the "
+                          "current user",
+                          result.output)
+
+            # Removing the --startupdata option should work just fine
+
+            argstring = "app start 1"
+            runner = CliRunner()
+            result = runner.invoke(remoteapprest.cli,
+                                   argstring.split(),
+                                   catch_exceptions=True)
+
+            self.assertEqual(result.exit_code, -1)
+
+            # Same if the allow_startup_data policy is set to True
+
+            response = [mock.Mock()]
+            response[0].content = json.dumps(
+                {'items': {'1': {"image": {
+                    "policy": {"allow_startup_data": True}
+                }}}}
+            ).encode("utf-8")
+
+            mock_get.side_effect = response
+
+            argstring = "app start 1 --startupdata=/test"
+            runner = CliRunner()
+            result = runner.invoke(remoteapprest.cli,
+                                   argstring.split(),
+                                   catch_exceptions=True)
+
+            self.assertEqual(result.exit_code, -1)
+
     def test_app_stop(self):
         with mock.patch('requests.delete') as mock_delete, \
                 mock.patch("remoteappmanager.cli.remoteapprest.__main__."


### PR DESCRIPTION
Closes #565 

The `remoteapprest app start` CLI command now accept a `--startupdata` option to provide a file path that will be loaded at startup. 

Note: the URL returned by the `remoteapprest app start` command cannot be used to open the container yet; there are two issues with it:

- the port referred in the URL is not correct
- the URL contains an extra `/api/v1/` that needs to be removed

The correct URL is the one printed in the logs; working on a way to return it through `remoteapprest`. 