### PR TITLE
Return usable URL from remoteapprest app start

### DIFF
--- a/remoteappmanager/cli/remoteapprest/__main__.py
+++ b/remoteappmanager/cli/remoteapprest/__main__.py
@@ -4,7 +4,7 @@ import os
 import requests
 import requests.utils
 import json
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import click
 
@@ -161,6 +161,11 @@ def start(ctx, identifier, startupdata):
                              verify=False)
     if response.status_code == 201:
         location = response.headers["Location"]
+        parsed = urlsplit(location)
+        path, port = parsed.path.split("_")
+        port = port.rstrip("/")
+        path = "".join(path.split("/api/v1"))
+        location = f"{parsed.scheme}://{parsed.hostname}:{port}{path}"
         print(location)
 
 

--- a/remoteappmanager/cli/remoteapprest/__main__.py
+++ b/remoteappmanager/cli/remoteapprest/__main__.py
@@ -137,9 +137,12 @@ def available(ctx):
 
 @app.command()
 @click.argument("identifier")
+@click.option("--startupdata", default=None)
 @click.pass_context
-def start(ctx, identifier):
+def start(ctx, identifier, startupdata):
     """Starts a container for application identified by IDENTIFIER.
+    If ``startupdata`` is provided, the container will open the given file at
+    startup.
     If a container is already running, restarts it."""
     cred = ctx.obj.credentials
     url, username, cookies = cred.url, cred.username, cred.cookies
@@ -147,9 +150,12 @@ def start(ctx, identifier):
     request_url = urljoin(url,
                           "/user/{}/api/v1/containers/".format(username))
 
-    payload = json.dumps(dict(
-        mapping_id=identifier
-    ))
+    payload_dict = dict(mapping_id=identifier)
+    if startupdata is not None:
+        payload_dict.update(
+            configurables=dict(startupdata=dict(startupdata=startupdata)))
+
+    payload = json.dumps(payload_dict)
 
     response = requests.post(request_url, payload, cookies=cookies,
                              verify=False)

--- a/remoteappmanager/cli/tests/test_remoteapprest.py
+++ b/remoteappmanager/cli/tests/test_remoteapprest.py
@@ -141,6 +141,18 @@ class TestRemoteAppREST(TempMixin, unittest.TestCase):
             self.assertEqual(mock_post.call_args[0][1],
                              json.dumps({"mapping_id": "1"}))
 
+            self._remoteapprest("app start 1 --startupdata=/test")
+            self.assertEqual(mock_post.call_args[0][0],
+                             "/user/bar/api/v1/containers/")
+            self.assertEqual(
+                mock_post.call_args[0][1],
+                json.dumps(
+                    {"mapping_id": "1",
+                     "configurables": {
+                         "startupdata": {"startupdata": "/test"}
+                     }}
+                ))
+
     def test_app_stop(self):
         with mock.patch('requests.delete') as mock_delete, \
                 mock.patch("remoteappmanager.cli.remoteapprest.__main__."

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -349,11 +349,9 @@ class ContainerManager(LoggingMixin):
             '\n'.join('{0} -> {1}'.format(source, target['bind'])
                       for source, target in filtered_volumes.items()))
 
-        container_url_id = _generate_container_url_id()
+        container_url_id = image_name.split("/")[-1]
         container_urlpath = without_end_slash(
-            url_path_join(base_urlpath,
-                          "containers",
-                          container_url_id))
+            url_path_join(base_urlpath, "containers", container_url_id))
         container_name = _generate_container_name(self.realm,
                                                   user_name,
                                                   mapping_id)
@@ -407,23 +405,16 @@ class ContainerManager(LoggingMixin):
         try:
             ip, port = yield from self._get_ip_and_port(container_id)
         except Exception as e:
-            self.log.exception(
-                "Could not retrieve ip/port information "
-                "for container {}".format(container_id))
+            self.log.exception("Could not retrieve ip/port information "
+                               "for container {}".format(container_id))
             yield self.stop_and_remove_container(container_id)
             raise e
 
-        container = Container(
-            docker_id=container_id,
-            name=container_name,
-            image_name=image_name,
-            image_id=image_id,
-            mapping_id=mapping_id,
-            ip=ip,
-            port=port,
-            url_id=container_url_id,
-            urlpath=container_urlpath,
-        )
+        extended_id = f"{container_url_id}_{port}"
+
+        container = Container(docker_id=container_id, name=container_name, image_name=image_name,
+            image_id=image_id, mapping_id=mapping_id, ip=ip, port=port, url_id=extended_id,
+            urlpath=container_urlpath, )
 
         self.log.info(
             ("Started container '{}' (id: {}). "

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -349,7 +349,7 @@ class ContainerManager(LoggingMixin):
             '\n'.join('{0} -> {1}'.format(source, target['bind'])
                       for source, target in filtered_volumes.items()))
 
-        container_url_id = image_name.split("/")[-1]
+        container_url_id = _generate_container_url_id(image_name)
         container_urlpath = without_end_slash(
             url_path_join(base_urlpath,
                           "containers",
@@ -693,8 +693,22 @@ def _generate_container_name(realm, user_name, mapping_id):
                                 )
 
 
-def _generate_container_url_id():
-    """Generates a unique string to identify the container through a url"""
+def _generate_container_url_id(image_name=None):
+    """ If a complete image name is provided, parses and returns the image
+    name, otherwise generates a unique string to identify the container.
+
+    Parameters
+    ----------
+    image_name : str, default None
+        The image name, in the format simphony-remote/simphony-application.
+
+    Returns
+    -------
+    str
+        The container identifier.
+    """
+    if image_name:
+        return image_name.split("/")[-1]
     return uuid.uuid4().hex
 
 

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -351,7 +351,9 @@ class ContainerManager(LoggingMixin):
 
         container_url_id = image_name.split("/")[-1]
         container_urlpath = without_end_slash(
-            url_path_join(base_urlpath, "containers", container_url_id))
+            url_path_join(base_urlpath,
+                          "containers",
+                          container_url_id))
         container_name = _generate_container_name(self.realm,
                                                   user_name,
                                                   mapping_id)
@@ -405,20 +407,35 @@ class ContainerManager(LoggingMixin):
         try:
             ip, port = yield from self._get_ip_and_port(container_id)
         except Exception as e:
-            self.log.exception("Could not retrieve ip/port information "
-                               "for container {}".format(container_id))
+            self.log.exception(
+                "Could not retrieve ip/port information "
+                "for container {}".format(container_id))
             yield self.stop_and_remove_container(container_id)
             raise e
 
         extended_id = f"{container_url_id}_{port}"
 
-        container = Container(docker_id=container_id, name=container_name, image_name=image_name,
-            image_id=image_id, mapping_id=mapping_id, ip=ip, port=port, url_id=extended_id,
-            urlpath=container_urlpath, )
+        container = Container(
+            docker_id=container_id,
+            name=container_name,
+            image_name=image_name,
+            image_id=image_id,
+            mapping_id=mapping_id,
+            ip=ip,
+            port=port,
+            url_id=extended_id,
+            urlpath=container_urlpath,
+        )
 
-        self.log.info(("Started container '{}' (id: {}). "
-                       "Exported port reachable at {}:{}").format(container_name, container_id, ip,
-            port))
+        self.log.info(
+            ("Started container '{}' (id: {}). "
+             "Exported port reachable at {}:{}").format(
+                container_name,
+                container_id,
+                ip,
+                port
+            )
+        )
 
         return container
 

--- a/remoteappmanager/docker/container_manager.py
+++ b/remoteappmanager/docker/container_manager.py
@@ -416,15 +416,9 @@ class ContainerManager(LoggingMixin):
             image_id=image_id, mapping_id=mapping_id, ip=ip, port=port, url_id=extended_id,
             urlpath=container_urlpath, )
 
-        self.log.info(
-            ("Started container '{}' (id: {}). "
-             "Exported port reachable at {}:{}").format(
-                container_name,
-                container_id,
-                ip,
-                port
-            )
-        )
+        self.log.info(("Started container '{}' (id: {}). "
+                       "Exported port reachable at {}:{}").format(container_name, container_id, ip,
+            port))
 
         return container
 


### PR DESCRIPTION
Closes #567 

[Includes changes from #566, changes will clean once that PR is merged]

Passing the right port to the response parsed by `remoteapprest app start` seems to be quite convoluted, so here is an approach which is a bit of a cheating, but it works and doesn't affect any other functionality. 

The container name is changed to include the right host port (e.g. "/simphony-remote_49165"), however this new name is not used internally (in fact it doesn't show in the logs); the container URL is still e.g. "http://127.0.0.1:49165/user/rpreste/containers/simphony-paraview/", because it is generated earlier in the process.

The new alternative URL is not functional, but it is sent in the response to the `remoteapprest app start` call, so it can then be parsed and rearranged to return the correct URL.