### PR TITLE
Fix User demo application assignment

### DIFF
--- a/jupyterhub/remoteappmanager_config.py
+++ b/jupyterhub/remoteappmanager_config.py
@@ -63,7 +63,12 @@
 # database_class = "remoteappmanager.db.orm.ORMDatabase"
 # database_kwargs = {
 #     "url": "sqlite:///"+os.path.abspath('./remoteappmanager.db')}
-
+#
+# # User accounting
+#
+# auto_user_creation = True
+# demo_applications = ['my-demo-app']
+#
 # # ----------------
 # # Google Analytics
 # # ----------------

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -168,17 +168,18 @@ class BaseApplication(web.Application, LoggingMixin):
     # Private
     def _add_demo_apps(self, user):
         """Grant access to any demo applications provided for user"""
-
-        if user.demo_applications:
+        if not user.demo_applications:
+            self.log.debug("No demo applications available")
             return
 
         # Add all demo applications already registered
         for application in self.db.list_applications():
             if application.image in user.demo_applications:
-                self.log.info(application.image)
+                self.log.debug(f"Avaliable image: {application.image}")
                 self.db.grant_access(
                     application.image,
                     user.name,
+                    '',
                     False,
                     True,
                     None

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -136,6 +136,8 @@ class BaseApplication(web.Application, LoggingMixin):
             self.log.info(
                 "Creating new User account for {}:".format(user.name))
             self.db.create_user(user.name)
+        else:
+            self.log.info("User account found for {}:".format(user.name))
 
         self.log.info("Adding demo apps to User registry:")
         self._add_demo_apps(user)

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -182,7 +182,8 @@ class BaseApplication(web.Application, LoggingMixin):
                     '',
                     False,
                     True,
-                    None
+                    None,
+                    True
                 )
 
     def _webapi_resources(self):

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -131,13 +131,12 @@ class BaseApplication(web.Application, LoggingMixin):
         user_name = self.command_line_config.user
         login_service = self.command_line_config.login_service
         user = User(name=user_name, login_service=login_service)
-        user.account = self.db.get_user(user_name=user_name)
-        if user.account is None:
+        while self.db.get_user(user_name=user.name) is None:
             self.log.info(
                 "Creating new User account for {}:".format(user.name))
             self.db.create_user(user.name)
-        else:
-            self.log.info("User account found for {}:".format(user.name))
+        user.account = self.db.get_user(user_name=user.name)
+        self.log.info("User account loaded for {}:".format(user.name))
 
         self.log.info("Adding demo apps to User registry:")
         self._add_demo_apps(user)

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -191,7 +191,7 @@ class BaseApplication(web.Application, LoggingMixin):
         # Add all demo applications already registered
         for application in self.db.list_applications():
             if application.image in self.file_config.demo_applications:
-                self.log.debug(f"Avaliable image: {application.image}")
+                self.log.debug(f"Available image: {application.image}")
                 self.db.grant_access(
                     application.image,
                     user.name,

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -132,6 +132,10 @@ class BaseApplication(web.Application, LoggingMixin):
         login_service = self.command_line_config.login_service
         user = User(name=user_name, login_service=login_service)
         user.account = self.db.get_user(user_name=user_name)
+        if user.account is None:
+            self.log.info(
+                "Creating new User account for {}:".format(user.name))
+            self.db.create_user(user.name)
 
         self.log.info("Adding demo apps to User registry:")
         self._add_demo_apps(user)

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -138,7 +138,8 @@ class BaseApplication(web.Application, LoggingMixin):
 
         # Handle User accounting
         if self.db.get_user(user_name=user.name) is None:
-            self.log.warning("User account not found for {}:".format(user.name))
+            self.log.warning(
+                "User account not found for {}:".format(user.name))
             if self.auto_user_creation:
                 self.log.info(
                     "Creating new User account for {}:".format(user.name))

--- a/remoteappmanager/file_config.py
+++ b/remoteappmanager/file_config.py
@@ -2,7 +2,7 @@ import os
 
 import tornado.options
 from docker import tls
-from traitlets import HasTraits, Int, Unicode, Bool, Dict
+from traitlets import HasTraits, List, Int, Unicode, Bool, Dict
 
 from remoteappmanager import paths
 from remoteappmanager.traitlets import set_traits_from_dict
@@ -70,6 +70,13 @@ class FileConfig(HasTraits):
     ga_tracking_id = Unicode(
         help="The google analytics tracking id"
     )
+
+    #: Provide names of any default applications granted to users
+    demo_applications = List()
+
+    #: Whether or not to automatically create user accounts upon starting
+    #: up the application if they do not already exist in the database
+    auto_user_creation = Bool(False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -50,7 +50,7 @@ class TestApplication(TempMixin,
         self.assertIsNotNone(app.container_manager)
         self.assertIsNotNone(app.hub)
         self.assertEqual(app.user.name, "johndoe")
-        self.assertNotNone(app.user.account)
+        self.assertIsNotNone(app.user.account)
 
     def test_error_default_value_with_unimportable_accounting(self):
         self.file_config.database_class = "not.importable.Class"

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -50,6 +50,38 @@ class TestApplication(TempMixin,
         self.assertIsNotNone(app.container_manager)
         self.assertIsNotNone(app.hub)
         self.assertEqual(app.user.name, "johndoe")
+        self.assertEqual(app.user.login_service, "")
+        self.assertIsNone(app.user.account)
+
+    def test_initialization_with_sqlite_db_and_auto_user_creation(self):
+        # Initialise database
+        sqlite_file_path = os.path.join(self.tempdir, "sqlite.db")
+        utils.init_sqlite_db(sqlite_file_path)
+
+        self.file_config.database_class = (
+            "remoteappmanager.db.orm.ORMDatabase")
+        self.file_config.database_kwargs = {
+            "url": "sqlite:///"+sqlite_file_path}
+
+        # Mimic assigning Application state in JupyterHub configuration
+        # file
+        Application.auto_user_creation = True
+
+        app = Application(self.command_line_config,
+                          self.file_config,
+                          self.environment_config)
+
+        self.assertIsNotNone(app.command_line_config)
+        self.assertIsNotNone(app.file_config)
+        self.assertIsNotNone(app.environment_config)
+
+        self.assertIsNotNone(app.db)
+        self.assertIsNotNone(app.user)
+        self.assertIsNotNone(app.reverse_proxy)
+        self.assertIsNotNone(app.container_manager)
+        self.assertIsNotNone(app.hub)
+        self.assertEqual(app.user.name, "johndoe")
+        self.assertEqual(app.user.login_service, "")
         self.assertIsNotNone(app.user.account)
 
     def test_error_default_value_with_unimportable_accounting(self):

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -50,7 +50,7 @@ class TestApplication(TempMixin,
         self.assertIsNotNone(app.container_manager)
         self.assertIsNotNone(app.hub)
         self.assertEqual(app.user.name, "johndoe")
-        self.assertEqual(app.user.account, None)
+        self.assertNotNone(app.user.account)
 
     def test_error_default_value_with_unimportable_accounting(self):
         self.file_config.database_class = "not.importable.Class"

--- a/remoteappmanager/tests/test_user.py
+++ b/remoteappmanager/tests/test_user.py
@@ -12,6 +12,6 @@ class TestUser(TestCase):
 
     def test_init(self):
         self.assertEqual('test-user', self.user.name)
-        self.assertNone(self.user.account)
+        self.assertIsNone(self.user.account)
         self.assertEqual('Basic', self.user.login_service)
         self.assertListEqual(['some-image'], self.user.demo_applications)

--- a/remoteappmanager/tests/test_user.py
+++ b/remoteappmanager/tests/test_user.py
@@ -14,4 +14,3 @@ class TestUser(TestCase):
         self.assertEqual('test-user', self.user.name)
         self.assertIsNone(self.user.account)
         self.assertEqual('Basic', self.user.login_service)
-        self.assertListEqual(['some-image'], self.user.demo_applications)

--- a/remoteappmanager/tests/test_user.py
+++ b/remoteappmanager/tests/test_user.py
@@ -6,13 +6,12 @@ from remoteappmanager.user import User
 class TestUser(TestCase):
 
     def setUp(self):
+        self.user = User(name='test-user',
+                         login_service='Basic',
+                         demo_applications=['some-image'])
 
-        self.user = User()
-
-    def test_demo_applications(self):
-
-        self.assertListEqual([], self.user.demo_applications)
-        self.assertListEqual(
-            [],
-            self.user.demo_applications
-        )
+    def test_init(self):
+        self.assertEqual('test-user', self.user.name)
+        self.assertNone(self.user.account)
+        self.assertEqual('Basic', self.user.login_service)
+        self.assertListEqual(['some-image'], self.user.demo_applications)

--- a/remoteappmanager/user.py
+++ b/remoteappmanager/user.py
@@ -1,4 +1,4 @@
-from traitlets import HasTraits, Unicode, Any, List
+from traitlets import HasTraits, Unicode, Any
 
 
 class User(HasTraits):

--- a/remoteappmanager/user.py
+++ b/remoteappmanager/user.py
@@ -1,4 +1,4 @@
-from traitlets import HasTraits, Unicode, Any
+from traitlets import HasTraits, Unicode, Any, List
 
 
 class User(HasTraits):
@@ -14,8 +14,6 @@ class User(HasTraits):
     #: Reference to the authenticator method used for user login
     login_service = Unicode()
 
-    @property
-    def demo_applications(self):
-        """Can be implemented to provide any default applications
-        granted by the user"""
-        return []
+    #: Provide names of any default applications granted to the user
+    #: This can be set in the JupyterHub configuration file
+    demo_applications = List().tag(config=True)

--- a/remoteappmanager/user.py
+++ b/remoteappmanager/user.py
@@ -13,7 +13,3 @@ class User(HasTraits):
 
     #: Reference to the authenticator method used for user login
     login_service = Unicode()
-
-    #: Provide names of any default applications granted to the user
-    #: This can be set in the JupyterHub configuration file
-    demo_applications = List().tag(config=True)


### PR DESCRIPTION
Small fixes and enhancements required to allow a set of demo applications provided to all new users to be declared in the `jupyterhub/remoteappmanager_config.py` .

This is achieved by introducing two features:
- `FileConfig.demo_applications` can be configured with a list of image names that are already registered with the application
- `FileConfig.auto_user_creation` can be configured to allow automatic registration of any authenticated user. If set to `True`, as long as the user can login via the declared `c.JupyterHub.authenticator_class`, then an account will be automatically created in the Simphony-Remote database. Otherwise an admin user will have to manually perform the task

Examples of how these may be assigned are given in `jupyterhub/remoteappmanager_config.py`
