### PR TITLE
Run CI regularly twice a month

### DIFF
--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '59 23 7,22 1-12 *'
 
   workflow_dispatch:
 

--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CentOS CI
 
 on:
   push:

--- a/.github/workflows/build_test_ubuntu18.yml
+++ b/.github/workflows/build_test_ubuntu18.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '59 23 7,22 1-12 *'
 
   workflow_dispatch:
 

--- a/.github/workflows/build_test_ubuntu18.yml
+++ b/.github/workflows/build_test_ubuntu18.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Ubuntu CI
 
 on:
   push:


### PR DESCRIPTION
Run CI regularly twice a month to discover dependency issues (like #574) earlier. Currently they're arbitrarily scheduled for the 7th and 22nd days of the month.

From the documentation of [`on.schedule`](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onschedule):
> Scheduled workflows run on the latest commit on the default or base branch.

Closes #549