### PR TITLE
Introduce Readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     python: "3.7"
 
 sphinx:
-   configuration: docs/source/conf.py
+   configuration: doc/source/conf.py
 
 python:
    install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 formats: all
 
 build:
-  os: ubuntu-18.04
+  os: ubuntu-20.04
   tools:
     python: "3.7"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Readthedocs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Readthedocs configuration file version
+version: 2
+
+# Additional document formats to produce
+formats: all
+
+build:
+  os: ubuntu-18.04
+  tools:
+    python: "3.7"
+
+sphinx:
+   configuration: docs/source/conf.py
+
+python:
+   install:
+   - requirements: doc-requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,3 +18,5 @@ sphinx:
 python:
    install:
    - requirements: doc-requirements.txt
+   - method: pip
+     path: .

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,7 @@ class install(_install):
         if not on_rtd:
             import subprocess
             subprocess.check_call(['npm', 'run', 'build'])
-        # Workaround for setuptools ignoring `install_requires` when
-        # `cmdclass` is overridden. See https://stackoverflow.com/q/21915469
-        super().do_egg_install()
+        super().run()
 
 
 # main setup configuration class


### PR DESCRIPTION
Introduce an explicit config file for Readthedocs, `.readthedocs.yaml` and hence close #585.

Side effect: support for installing `remoteappmanager` using `python setup.py install` is removed. (See also #577 where it was originally introduced.)