### PR TITLE
Trigger Readthedocs builds regularly

### DIFF
--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -1,5 +1,13 @@
 name: Trigger documentation build on Readthedocs
 
+# on:
+#   schedule:
+#     # Run this action twice a month just before midnight UTC
+#     # "*" is a special character in YAML, so we have to quote this string
+#     - cron:  '59 23 7,22 1-12 *'
+#   workflow_dispatch:
+
+# Try the workaround documented here: https://github.community/t/new-action-isnt-showing/128287/4
 on:
   schedule:
     # Run this action twice a month just before midnight UTC

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -1,7 +1,6 @@
 name: Trigger documentation build on Readthedocs
 
 on:
-  push:
   schedule:
     # Run this action twice a month just before midnight UTC
     # "*" is a special character in YAML, so we have to quote this string

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -6,10 +6,11 @@ on:
     # Run this action twice a month just before midnight UTC
     # "*" is a special character in YAML, so we have to quote this string
     - cron:  '59 23 7,22 1-12 *'
+  workflow_dispatch:
 
 jobs:
   trigger_readthedocs_build:
     runs-on: ubuntu-18.04
 
     steps:
-      - run: echo 1
+      - run: curl -X POST -d "token=${{ secrets.RTD_WEBHOOK_TOKEN }}" "${{ secrets.RTD_WEBHOOK_URL }}"

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -1,6 +1,11 @@
 name: Trigger documentation build on Readthedocs
 
-on: push
+on:
+  push:
+  schedule:
+    # Run this action twice a month just before midnight UTC
+    # "*" is a special character in YAML, so we have to quote this string
+    - cron:  '59 23 7,22 1-12 *'
 
 jobs:
   trigger_readthedocs_build:

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Run this action twice a month just before midnight UTC
     # "*" is a special character in YAML, so we have to quote this string
-    - cron:  '28 11 17 1-12 *'
+    - cron:  '45 11 17 1-12 *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Run this action twice a month just before midnight UTC
     # "*" is a special character in YAML, so we have to quote this string
-    - cron:  '59 23 7,22 1-12 *'
+    - cron:  '28 11 17 1-12 *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -1,0 +1,18 @@
+name: Trigger documentation build on Readthedocs
+
+on:
+  schedule:
+    # Run this action twice a month just before midnight UTC
+    # "*" is a special character in YAML, so we have to quote this string
+    - cron:  '59 23 7,22 1-12 *'
+  workflow_dispatch:
+
+jobs:
+  trigger_readthedocs_build:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - run: |
+          curl -X POST \
+            -d "token=${{ secrets.RTD_WEBHOOK_TOKEN }}" \
+            "${{ secrets.RTD_WEBHOOK_URL }}"

--- a/.github/workflows/trigger_doc_build.yml
+++ b/.github/workflows/trigger_doc_build.yml
@@ -1,26 +1,10 @@
 name: Trigger documentation build on Readthedocs
 
-# on:
-#   schedule:
-#     # Run this action twice a month just before midnight UTC
-#     # "*" is a special character in YAML, so we have to quote this string
-#     - cron:  '59 23 7,22 1-12 *'
-#   workflow_dispatch:
-
-# Try the workaround documented here: https://github.community/t/new-action-isnt-showing/128287/4
-on:
-  schedule:
-    # Run this action twice a month just before midnight UTC
-    # "*" is a special character in YAML, so we have to quote this string
-    - cron:  '59 23 7,22 1-12 *'
-  workflow_dispatch:
+on: push
 
 jobs:
   trigger_readthedocs_build:
     runs-on: ubuntu-18.04
 
     steps:
-      - run: |
-          curl -X POST \
-            -d "token=${{ secrets.RTD_WEBHOOK_TOKEN }}" \
-            "${{ secrets.RTD_WEBHOOK_URL }}"
+      - run: echo 1


### PR DESCRIPTION
Create a new scheduled GitHub action to trigger documentation builds on Readthedocs automatically. In addition to the builds initiated by PRs, this makes sure that the builds are run even if there is no development on this repo. With this changes to external dependencies will be discovered earlier and this will make it easier to maintain the documentation workflow in the future.

Closes #584.