### PR TITLE
Add Spawner options to enable admins to spawn user sessions

### DIFF
--- a/doc/source/administration.rst
+++ b/doc/source/administration.rst
@@ -10,10 +10,13 @@ applications, and authorize users to run specific applications. It is also possi
 currently running containers
 
     **NOTE**: the existing "Admin" or "User" session must be shut down before the options form
-    will be shown again. This is a JupyterHub-level operation and is not automatically performed
-    upon logging out. Therefore it must be manually carried out by either navigating to
+    will be shown again. This is a JupyterHub-level operation and is not performed by default
+    upon logging out. Typically it must be manually carried out by either navigating to
     ``https://<simphony-remote>/hub/admin`` or ``https://<simphony-remote>/hub/home`` whilst logged
-    in and selecting the appropriate the "Stop My Sever" option.
+    in and selecting the appropriate the "Stop My Sever" option. For convenience we provide a custom
+    logout handler that automatically shuts down sessions upon an administrator sign out. This can be
+    used with any ``jupyterhub.auth.Authenticator`` subclass via inheriting the
+    ``remoteappmanager.jupyterhub.auth.SimphonyRemoteAuthMixin`` mixin.
 
 It is important to note that the administrative interface works only with
 accounting backends supporting addition and removal. More specifically, it

--- a/doc/source/administration.rst
+++ b/doc/source/administration.rst
@@ -1,11 +1,12 @@
 Administration
 ==============
 
-As specified in the deployment section, the authenticator will grant administrative
-rights to users in the specified set. 
-Once logged in, an administrative user will be served by a different application,
-where it can add or remove users, applications, and authorize users to run specific
-applications. It is also possible to stop currently running containers.
+As specified in the configuration section, the authenticator will grant additional
+administrative rights to users in the specified set.
+
+Once logged in, an administrative user will have the option to spawn an "Admin" session,
+providing them with a different application, where they can add or remove users,
+applications, and authorize users to run specific applications. It is also possible to stop currently running containers
 
 It is important to note that the administrative interface works only with
 accounting backends supporting addition and removal. More specifically, it

--- a/doc/source/administration.rst
+++ b/doc/source/administration.rst
@@ -6,7 +6,14 @@ administrative rights to users in the specified set.
 
 Once logged in, an administrative user will have the option to spawn an "Admin" session,
 providing them with a different application, where they can add or remove users,
-applications, and authorize users to run specific applications. It is also possible to stop currently running containers
+applications, and authorize users to run specific applications. It is also possible to stop
+currently running containers
+
+    **NOTE**: the existing "Admin" or "User" session must be shut down before the options form
+    will be shown again. This is a JupyterHub-level operation and is not automatically performed
+    upon logging out. Therefore it must be manually carried out by either navigating to
+    ``https://<simphony-remote>/hub/admin`` or ``https://<simphony-remote>/hub/home`` whilst logged
+    in and selecting the appropriate the "Stop My Sever" option.
 
 It is important to note that the administrative interface works only with
 accounting backends supporting addition and removal. More specifically, it

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -37,8 +37,8 @@ Administration capabilities are decided by jupyterhub, not remoteappmanager.
     c.Authenticator.admin_users = {"admin"}
 
 Note that the entry must be a python set. Users in this set will, once logged
-in, reach an administrative interface, instead of the docker application
-management.
+in, be able to launch an administrative interface in addition to the standard
+docker application management.
 
 .. _config_remoteappmanager:
 

--- a/remoteappmanager/jupyterhub/auth/__init__.py
+++ b/remoteappmanager/jupyterhub/auth/__init__.py
@@ -1,3 +1,4 @@
 from .world_authenticator import WorldAuthenticator  # noqa
 from .basic_authenticator import BasicAuthenticator  # noqa
 from .github_whitelist_authenticator import GitHubWhitelistAuthenticator  # noqa
+from .simphony_remote_auth_mixin import SimphonyRemoteAuthMixin  # noqa

--- a/remoteappmanager/jupyterhub/auth/basic_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/basic_authenticator.py
@@ -3,8 +3,10 @@ from tornado import gen
 from jupyterhub.auth import Authenticator
 from traitlets import Dict
 
+from .simphony_remote_auth_mixin import SimphonyRemoteAuthMixin
 
-class BasicAuthenticator(Authenticator):
+
+class BasicAuthenticator(SimphonyRemoteAuthMixin, Authenticator):
     """ Simple authenticator based on a fixed set of users"""
 
     #: Dictionary of regular username: password keys allowed

--- a/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/github_whitelist_authenticator.py
@@ -3,6 +3,8 @@ from oauthenticator import GitHubOAuthenticator
 from traitlets.config import LoggingConfigurable
 from traitlets import Unicode, Float, Set
 
+from .simphony_remote_auth_mixin import SimphonyRemoteAuthMixin
+
 
 class FileWhitelistMixin(LoggingConfigurable):
     """
@@ -59,7 +61,8 @@ class FileWhitelistMixin(LoggingConfigurable):
         pass
 
 
-class GitHubWhitelistAuthenticator(FileWhitelistMixin, GitHubOAuthenticator):
+class GitHubWhitelistAuthenticator(
+        SimphonyRemoteAuthMixin, FileWhitelistMixin, GitHubOAuthenticator):
     """A github authenticator that also verifies that the
     user belongs to a specified whitelisted user as provided
     by an external file (so that we don't have to restart

--- a/remoteappmanager/jupyterhub/auth/simphony_remote_auth_mixin.py
+++ b/remoteappmanager/jupyterhub/auth/simphony_remote_auth_mixin.py
@@ -1,0 +1,35 @@
+from jupyterhub.handlers import LogoutHandler as _LogoutHandler
+from jupyterhub.handlers import LoginHandler
+
+
+class LogoutHandler(_LogoutHandler):
+    def get(self):
+        user = self.get_current_user()
+        if user:
+            # Ensures admin sessions are shut down when user
+            # logs out so that the spawner options form is
+            # shown upon subsequent logins
+            # TODO: replace for configuring shutdown_on_logout option
+            #  once running on jupyterhub>=1.0.0
+            if user.admin and user.spawner is not None:
+                self.log.info(f"Shutting down {user.name}'s server")
+                self.stop_single_user(user)
+            self.log.info("User logged out: %s", user.name)
+            self.clear_login_cookie()
+            for name in user.other_user_cookies:
+                self.clear_login_cookie(name)
+            user.other_user_cookies = set([])
+            self.statsd.incr('logout')
+        self.redirect(self.settings['login_url'], permanent=False)
+
+
+class SimphonyRemoteAuthMixin:
+
+    def get_handlers(self, app):
+        """Includes standard LoginHandler and modified LogoutHandler that
+        closes admin sessions upon signing out
+        """
+        return [
+            ('/login', LoginHandler),
+            ('/logout', LogoutHandler)
+        ]

--- a/remoteappmanager/jupyterhub/auth/world_authenticator.py
+++ b/remoteappmanager/jupyterhub/auth/world_authenticator.py
@@ -5,8 +5,10 @@ from tornado import gen
 
 from jupyterhub.auth import Authenticator
 
+from .simphony_remote_auth_mixin import SimphonyRemoteAuthMixin
 
-class WorldAuthenticator(Authenticator):
+
+class WorldAuthenticator(SimphonyRemoteAuthMixin, Authenticator):
     """ This authenticator authenticates everyone """
 
     @gen.coroutine

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -51,11 +51,11 @@ class BaseSpawner(LocalProcessSpawner):
             return """
             <div>
                 Choose RemoteAppManager Session:
-                <select id="session_form" name="session" multiple="false>
-                    <option value="admin" selected>Admin<option/>
-                    <option value="user" selected>User<option/>
-                <select/>
-            <div/>
+                <select id="session_form" name="session" multiple="false">
+                    <option value="admin" selected>Admin</option>
+                    <option value="user">User</option>
+                </select>
+            </div>
             """
         return ""
 

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -2,7 +2,7 @@ import os
 import escapism
 import string
 
-from traitlets import Any, Unicode
+from traitlets import Any, Unicode, default
 from tornado import gen
 
 from jupyterhub.spawner import LocalProcessSpawner
@@ -42,6 +42,7 @@ class BaseSpawner(LocalProcessSpawner):
         # contain only one.
         self.proxy = self.db.query(orm.Proxy).first()
 
+    @default("options_form")
     def _options_form_default(self):
         """ Gives admins the option of spawning either RemoteAppManager
         admin or user sessions
@@ -61,6 +62,7 @@ class BaseSpawner(LocalProcessSpawner):
     def _default_session(self):
         return "admin" if self.user.admin else "user"
 
+    @default("user_options")
     def _default_user_options(self):
         return {"session": self._default_session()}
 

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -28,11 +28,7 @@ class BaseSpawner(LocalProcessSpawner):
     def cmd(self):
         """Overrides the base class traitlet so that we take full control
         of the spawned command according to user admin status"""
-        if not self.user.admin:
-            return [USER_CMD]
-        return ([ADMIN_CMD]
-                if self.user_options['session'] == "admin"
-                else [USER_CMD])
+        return self.user_options.get('cmd', self._default_cmd())
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -59,19 +55,17 @@ class BaseSpawner(LocalProcessSpawner):
             """
         return ""
 
-    def _default_session(self):
-        return "admin" if self.user.admin else "user"
-
-    @default("user_options")
-    def _default_user_options(self):
-        return {"session": self._default_session()}
+    def _default_cmd(self):
+        return ADMIN_CMD if self.user.admin else USER_CMD
 
     def options_from_form(self, form_data):
         """ Attempt to extract session selection from HTML form and
         return default session if not available
         """
-        session = form_data.get("session", [self._default_session()])[0]
-        return {'session': session}
+        cmd = self._default_cmd()
+        if "session" in form_data:
+            cmd = ADMIN_CMD if form_data.pop("session")[0] == "admin" else USER_CMD
+        return {'cmd': cmd}
 
     def get_args(self):
         args = super().get_args()

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -28,7 +28,7 @@ class BaseSpawner(LocalProcessSpawner):
     def cmd(self):
         """Overrides the base class traitlet so that we take full control
         of the spawned command according to user admin status"""
-        return self.user_options.get('cmd', self._default_cmd())
+        return [self.user_options.get('cmd', self._default_cmd())]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -28,7 +28,7 @@ class BaseSpawner(LocalProcessSpawner):
     def cmd(self):
         """Overrides the base class traitlet so that we take full control
         of the spawned command according to user admin status"""
-        return [self.user_options.get('cmd', self._default_cmd())]
+        return self.user_options.get('cmd', self._default_cmd())
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -56,7 +56,7 @@ class BaseSpawner(LocalProcessSpawner):
         return ""
 
     def _default_cmd(self):
-        return ADMIN_CMD if self.user.admin else USER_CMD
+        return [ADMIN_CMD] if self.user.admin else [USER_CMD]
 
     def options_from_form(self, form_data):
         """ Attempt to extract session selection from HTML form and
@@ -64,7 +64,8 @@ class BaseSpawner(LocalProcessSpawner):
         """
         cmd = self._default_cmd()
         if "session" in form_data:
-            cmd = ADMIN_CMD if form_data.pop("session")[0] == "admin" else USER_CMD
+            selected = form_data.pop("session")[0]
+            cmd = [ADMIN_CMD] if selected == "admin" else [USER_CMD]
         return {'cmd': cmd}
 
     def get_args(self):

--- a/remoteappmanager/jupyterhub/spawners.py
+++ b/remoteappmanager/jupyterhub/spawners.py
@@ -50,8 +50,8 @@ class BaseSpawner(LocalProcessSpawner):
         if self.user.admin:
             return """
             <div>
-                Choose RemoteAppManager Session:
-                <select id="session_form" name="session" multiple="false">
+                <label for="session">Choose RemoteAppManager Session:</label>
+                <select id="session_form" name="session" size="2">
                     <option value="admin" selected>Admin</option>
                     <option value="user">User</option>
                 </select>

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -93,7 +93,7 @@ class TestSystemUserSpawner(TempMixin, AsyncTestCase):
         self.assertIn("--base-urlpath=\"/\"", args)
 
     def test_cmd(self):
-        self.assertEqual(self.spawner.cmd, ['remoteappmanager'])
+        self.assertEqual(self.spawner.cmd, [USER_CMD])
 
     def test_default_config_file_path(self):
         self.assertEqual(self.spawner.config_file_path, "")
@@ -160,24 +160,24 @@ class TestSystemUserSpawnerAsAdmin(TestSystemUserSpawner):
         self.spawner.user.admin = True
 
     def test_cmd(self):
-        self.assertEqual(self.spawner.cmd, ['remoteappadmin'])
+        self.assertEqual(self.spawner.cmd, [ADMIN_CMD])
 
     def test_cmd_user_session_override(self):
-        self.spawner.user_options = {"cmd": USER_CMD}
-        self.assertEqual(self.spawner.cmd, ['remoteappmanager'])
+        self.spawner.user_options = {"cmd": [USER_CMD]}
+        self.assertEqual(self.spawner.cmd, [USER_CMD])
 
     def test_parse_options_from_form(self):
         self.assertEqual(
             self.spawner.options_from_form({}),
-            {"cmd": ADMIN_CMD}
+            {"cmd": [ADMIN_CMD]}
         )
         self.assertEqual(
             self.spawner.options_from_form({"session": ["user"]}),
-            {"cmd": USER_CMD}
+            {"cmd": [USER_CMD]}
         )
         self.assertEqual(
             self.spawner.options_from_form({"session": ["admin"]}),
-            {"cmd": ADMIN_CMD}
+            {"cmd": [ADMIN_CMD]}
         )
 
 

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -10,8 +10,7 @@ from tornado.testing import AsyncTestCase
 from jupyterhub import orm
 
 from remoteappmanager.jupyterhub.spawners import (
-    SystemUserSpawner,
-    VirtualUserSpawner)
+    ADMIN_CMD, USER_CMD, SystemUserSpawner, VirtualUserSpawner)
 from remoteappmanager.tests import fixtures
 from remoteappmanager.tests.temp_mixin import TempMixin
 
@@ -164,21 +163,21 @@ class TestSystemUserSpawnerAsAdmin(TestSystemUserSpawner):
         self.assertEqual(self.spawner.cmd, ['remoteappadmin'])
 
     def test_cmd_user_session_override(self):
-        self.spawner.user_options = {"session": "user"}
+        self.spawner.user_options = {"cmd": USER_CMD}
         self.assertEqual(self.spawner.cmd, ['remoteappmanager'])
 
     def test_parse_options_from_form(self):
         self.assertEqual(
             self.spawner.options_from_form({}),
-            {"session": "admin"}
+            {"cmd": ADMIN_CMD}
         )
         self.assertEqual(
             self.spawner.options_from_form({"session": ["user"]}),
-            {"session": "user"}
+            {"cmd": USER_CMD}
         )
         self.assertEqual(
             self.spawner.options_from_form({"session": ["admin"]}),
-            {"session": "admin"}
+            {"cmd": ADMIN_CMD}
         )
 
 

--- a/remoteappmanager/jupyterhub/tests/test_spawners.py
+++ b/remoteappmanager/jupyterhub/tests/test_spawners.py
@@ -163,6 +163,24 @@ class TestSystemUserSpawnerAsAdmin(TestSystemUserSpawner):
     def test_cmd(self):
         self.assertEqual(self.spawner.cmd, ['remoteappadmin'])
 
+    def test_cmd_user_session_override(self):
+        self.spawner.user_options = {"session": "user"}
+        self.assertEqual(self.spawner.cmd, ['remoteappmanager'])
+
+    def test_parse_options_from_form(self):
+        self.assertEqual(
+            self.spawner.options_from_form({}),
+            {"session": "admin"}
+        )
+        self.assertEqual(
+            self.spawner.options_from_form({"session": ["user"]}),
+            {"session": "user"}
+        )
+        self.assertEqual(
+            self.spawner.options_from_form({"session": ["admin"]}),
+            {"session": "admin"}
+        )
+
 
 class TestVirtualUserSpawner(TestSystemUserSpawner):
     def setUp(self):

--- a/selenium_tests/AdminDriverTest.py
+++ b/selenium_tests/AdminDriverTest.py
@@ -16,18 +16,6 @@ class AdminDriverTest(RemoteAppDriverTest):
         self.click_first_element_located(By.CSS_SELECTOR, "input.btn")
         self.click_first_element_located(By.ID, "start")
 
-    def admin_logout(self):
-        """ Admin Logout. Ensures user session is stopped before performing logout.
-        This action should be generally used whenever the Spawner options form is
-        presented during logins so that it is correctly displayed for the next test
-        runner.
-        """
-        self.driver.get(self.base_url + "/home")
-
-        self.click_first_element_located(By.ID, "stop")
-        self.click_first_element_located(By.ID, "logout")
-        self.wait_until_text_inside_element_located(By.CSS_SELECTOR, "div.auth-form-header", "Sign in")
-
     def setUp(self):
         RemoteAppDriverTest.setUp(self)
         self.admin_login()
@@ -104,5 +92,5 @@ class AdminDriverTest(RemoteAppDriverTest):
         )
 
     def tearDown(self):
-        self.admin_logout()
+        self.logout()
         RemoteAppDriverTest.tearDown(self)

--- a/selenium_tests/AdminDriverTest.py
+++ b/selenium_tests/AdminDriverTest.py
@@ -4,9 +4,32 @@ from selenium.webdriver.common.by import By
 
 
 class AdminDriverTest(RemoteAppDriverTest):
+
+    def admin_login(self):
+        """ Login as am admin user. We assume that if you use this routine,
+        you are currently on the login page.
+        """
+        self.login("admin")
+
+        self.click_first_element_located(By.ID, "start")
+        self.click_first_element_located(By.CSS_SELECTOR, "input.btn")
+        self.click_first_element_located(By.ID, "start")
+
+    def admin_logout(self):
+        """ Admin Logout. Ensures user session is stopped before performing logout.
+        This action should be generally used whenever the Spawner options form is
+        presented during logins so that it is correctly displayed for the next test
+        runner.
+        """
+        self.driver.get(self.base_url + "/home")
+
+        self.click_first_element_located(By.ID, "stop")
+        self.click_first_element_located(By.ID, "logout")
+        self.wait_until_text_inside_element_located(By.CSS_SELECTOR, "div.auth-form-header", "Sign in")
+
     def setUp(self):
         RemoteAppDriverTest.setUp(self)
-        self.login("admin")
+        self.admin_login()
 
     def wait_until_visibility_of_row(self, row):
         """ Wait until a specific row is visible
@@ -80,5 +103,5 @@ class AdminDriverTest(RemoteAppDriverTest):
         )
 
     def tearDown(self):
-        self.logout()
+        self.admin_login()
         RemoteAppDriverTest.tearDown(self)

--- a/selenium_tests/AdminDriverTest.py
+++ b/selenium_tests/AdminDriverTest.py
@@ -6,8 +6,9 @@ from selenium.webdriver.common.by import By
 class AdminDriverTest(RemoteAppDriverTest):
 
     def admin_login(self):
-        """ Login as am admin user. We assume that if you use this routine,
-        you are currently on the login page.
+        """ Login as an admin user. Handles both entering admin credentials
+        and selecting appropriate Spawner options. We assume that if you
+        use this routine, you are currently on the login page.
         """
         self.login("admin")
 
@@ -103,5 +104,5 @@ class AdminDriverTest(RemoteAppDriverTest):
         )
 
     def tearDown(self):
-        self.admin_login()
+        self.admin_logout()
         RemoteAppDriverTest.tearDown(self)

--- a/selenium_tests/RemoteAppDriverTest.py
+++ b/selenium_tests/RemoteAppDriverTest.py
@@ -247,15 +247,15 @@ class RemoteAppDriverTest(unittest.TestCase):
     def login(self, username="test"):
         """ Login as a given user name. We assume that if you use this routine,
         you are currently on the login page.
+
         Parameters
         ----------
         username: String
-            The name of the user, it can be "admin" if you want to login as admin.
+            The name of the user, it is not expected to be an admin.
 
         Example:
         --------
         login("JohnDoe")
-        login("admin")
         """
         self.driver.get(self.base_url + "/hub/login")
 

--- a/selenium_tests/test_spawner_options_form.py
+++ b/selenium_tests/test_spawner_options_form.py
@@ -5,18 +5,6 @@ from selenium.webdriver.common.by import By
 
 class TestSpawnerOptionsForm(RemoteAppDriverTest):
 
-    def admin_logout(self):
-        """ Admin Logout. Ensures user session is stopped before performing logout.
-        This action should be generally used whenever the Spawner options form is
-        presented during logins so that it is correctly displayed for the next test
-        runner.
-        """
-        self.driver.get(self.base_url + "/home")
-
-        self.click_first_element_located(By.ID, "stop")
-        self.click_first_element_located(By.ID, "logout")
-        self.wait_until_text_inside_element_located(By.CSS_SELECTOR, "div.auth-form-header", "Sign in")
-
     def test_admin_login_default_session(self):
         self.login("admin")
 
@@ -40,5 +28,5 @@ class TestSpawnerOptionsForm(RemoteAppDriverTest):
             By.CSS_SELECTOR, ".header", "APPLICATIONS")
 
     def tearDown(self):
-        self.admin_logout()
+        self.logout()
         RemoteAppDriverTest.tearDown(self)

--- a/selenium_tests/test_spawner_options_form.py
+++ b/selenium_tests/test_spawner_options_form.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from selenium_tests.RemoteAppDriverTest import RemoteAppDriverTest
+from selenium.webdriver.common.by import By
+
+
+class TestSpawnerOptionsForm(RemoteAppDriverTest):
+
+    def admin_logout(self):
+        """ Admin Logout. Ensures user session is stopped before performing logout.
+        This action should be generally used whenever the Spawner options form is
+        presented during logins so that it is correctly displayed for the next test
+        runner.
+        """
+        self.driver.get(self.base_url + "/home")
+
+        self.click_first_element_located(By.ID, "stop")
+        self.click_first_element_located(By.ID, "logout")
+        self.wait_until_text_inside_element_located(By.CSS_SELECTOR, "div.auth-form-header", "Sign in")
+
+    def test_admin_login_default_session(self):
+        self.login("admin")
+
+        self.click_first_element_located(By.ID, "start")
+        self.click_first_element_located(By.CSS_SELECTOR, "input.btn")
+        self.click_first_element_located(By.ID, "start")
+
+        self.wait_until_text_inside_element_located(
+            By.CSS_SELECTOR, ".header", "ADMIN")
+
+    def test_admin_login_user_session(self):
+        self.login("admin")
+
+        self.click_first_element_located(By.ID, "start")
+        self.click_first_element_located(
+            By.CSS_SELECTOR, "# spawner_form > options:nth-child(2)")
+        self.click_first_element_located(By.CSS_SELECTOR, "input.btn")
+        self.click_first_element_located(By.ID, "start")
+
+        self.wait_until_text_inside_element_located(
+            By.CSS_SELECTOR, ".header", "APPLICATIONS")
+
+    def tearDown(self):
+        self.admin_logout()
+        RemoteAppDriverTest.tearDown(self)

--- a/selenium_tests/test_spawner_options_form.py
+++ b/selenium_tests/test_spawner_options_form.py
@@ -32,7 +32,7 @@ class TestSpawnerOptionsForm(RemoteAppDriverTest):
 
         self.click_first_element_located(By.ID, "start")
         self.click_first_element_located(
-            By.CSS_SELECTOR, "# spawner_form > options:nth-child(2)")
+            By.CSS_SELECTOR, "#session_form > option:nth-child(2)")
         self.click_first_element_located(By.CSS_SELECTOR, "input.btn")
         self.click_first_element_located(By.ID, "start")
 


### PR DESCRIPTION
Closes #592

Makes use of JupyterHub's extendable spawner options form to provide admin users with the ability to spawn either "Admin" (`remoteappadmin`) or "User" (`remoteappmanager`) sessions when they login.

## Notes

The existing session must be closed before the options form will be shown again. For JupyterHub < 1.0.0, the only way to do this is by navigating to `https://<simphony-remote>/hub/admin` or `https://<simphony-remote>/hub/home` whilst logged in and selecting the "Stop My Sever" option. 

Therefore (for now) we include the `SimphonyRemoteAuthMixin` class, providing a logout handler that automatically closes admin user servers upon a sign out. This has no effect on the functionality of the application since any Simphony-Remote applications will continue to run even if the JupyterHub server is shut down.

For versions of JupyterHub >= 1.0.0, we can simply configure the `shutdown_on_logout` option to do this instead.