### PR TITLE
Fix RTD build failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools==21.0
+traitlets>=4.1
 tornado==5.1.1
 # Fix to 2.10.0 due to docker-py needs (fails with 2.11.1)
 requests==2.10.0
@@ -6,11 +7,10 @@ requests==2.10.0
 # on ubuntu uses 1.23, so they don't like each other.
 docker-py==1.8
 escapism==0.0.1
-# Pinned to 0.8.0.dev0 due to issues with spawners (fails with 0.8.0)
-git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5
 git+http://github.com/simphony/tornado-webapi.git@8b6846faae23657a04cf97ca5229ce8ea083d000#egg=tornadowebapi
 # Pinned to 0.10.0 since 0.11.0 does not seem to be compatible with jupyterhub 0.7.x
 oauthenticator==0.10.0
+tornadowebapi>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ tabulate==0.7.5
 tornadowebapi @ git+http://github.com/simphony/tornado-webapi.git@8b6846faae23657a04cf97ca5229ce8ea083d000#egg=tornadowebapi
 # Pinned to 0.10.0 since 0.11.0 does not seem to be compatible with jupyterhub 0.7.x
 oauthenticator==0.10.0
+jinja2>=2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ escapism==0.0.1
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5
-git+http://github.com/simphony/tornado-webapi.git@8b6846faae23657a04cf97ca5229ce8ea083d000#egg=tornadowebapi
+tornadowebapi @ git+http://github.com/simphony/tornado-webapi.git@8b6846faae23657a04cf97ca5229ce8ea083d000#egg=tornadowebapi
 # Pinned to 0.10.0 since 0.11.0 does not seem to be compatible with jupyterhub 0.7.x
 oauthenticator==0.10.0
-tornadowebapi>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ requests==2.10.0
 # on ubuntu uses 1.23, so they don't like each other.
 docker-py==1.8
 escapism==0.0.1
+# Pinned to jupyterhub 0.8.0.dev0 due to issues with spawners (fails with 0.8.0)
+jupyterhub @ git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub
 jupyter_client==4.3.0
 click==6.6
 tabulate==0.7.5

--- a/setup.py
+++ b/setup.py
@@ -23,17 +23,10 @@ def write_version_py():
 
 write_version_py()
 
-requirements = [
-    "setuptools>=21.0",
-    "traitlets>=4.1",
-    "tornado>=4.3",
-    "requests>=2.10.0",
-    "escapism>=0.0.1",
-    "jupyter_client>=4.3.0",
-    "click>=6.6",
-    "tabulate>=0.7.5",
-    "oauthenticator>=0.5",
-]
+with open('requirements.txt', 'r') as REQUIREMENTS:
+    requirements = [
+        line for line in REQUIREMENTS.readlines() if not line.startswith('#')
+    ]
 
 # Unfortunately RTD cannot install jupyterhub because jupyterhub needs bower,
 # and that is not available. We prevent the request for the unreleased jhub
@@ -43,6 +36,7 @@ requirements = [
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
+    print("Using ReadTheDocs build requirement")
     # These are the dependencies of jupyterhub that we need to have in order
     # for our code to import on RTD.
     requirements.extend([
@@ -55,9 +49,9 @@ if on_rtd:
 else:
     requirements.extend([
         "jinja>=2.8",
-        "jupyterhub>0.7",
-        "docker-py==1.8",
-        "tornadowebapi>=0.5.0"])
+        # Pinned to jupyterhub 0.8.0.dev0 due to issues with spawners (fails with 0.8.0)
+        "git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub",
+    ])
 
 
 class install(_install):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
     "tornado>=4.3",
     "requests>=2.10.0",
     "escapism>=0.0.1",
-    "jinja2>=2.8",
+    "jinja2<3.1.0",
     "jupyter_client>=4.3.0",
     "click>=6.6",
     "tabulate>=0.7.5",

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,10 @@ with open('requirements.txt', 'r') as REQUIREMENTS:
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
-    print("Using ReadTheDocs build requirement")
     # These are the dependencies of jupyterhub that we need to have in order
     # for our code to import on RTD.
     requirements.extend([
-        "sqlalchemy>=1.0"
+        "sqlalchemy>=1.0",
         # Pinning jinja2 requirements when building on RTD due to
         # regression when using old versions of sphinx<2
         # https://github.com/readthedocs/readthedocs.org/issues/9037

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ requirements = [
     "tornado>=4.3",
     "requests>=2.10.0",
     "escapism>=0.0.1",
-    "jinja2<3.1.0",
     "jupyter_client>=4.3.0",
     "click>=6.6",
     "tabulate>=0.7.5",
@@ -46,9 +45,16 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     # These are the dependencies of jupyterhub that we need to have in order
     # for our code to import on RTD.
-    requirements.extend(["sqlalchemy>=1.0"])
+    requirements.extend([
+        "sqlalchemy>=1.0"
+        # Pinning jinja2 requirements when building on RTD due to
+        # regression when using old versions of sphinx<2
+        # https://github.com/readthedocs/readthedocs.org/issues/9037
+        "jinja2<3.1.0",
+    ])
 else:
     requirements.extend([
+        "jinja>=2.8",
         "jupyterhub>0.7",
         "docker-py==1.8",
         "tornadowebapi>=0.5.0"])

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     # These are the dependencies of jupyterhub that we need to have in order
     # for our code to import on RTD.
+    requirements = [
+        dep for dep in requirements if not dep.startswith("jupyterhub")]
     requirements.extend([
         "sqlalchemy>=1.0",
         # Pinning jinja2 requirements when building on RTD due to
@@ -49,8 +51,6 @@ if on_rtd:
 else:
     requirements.extend([
         "jinja>=2.8",
-        # Pinned to jupyterhub 0.8.0.dev0 due to issues with spawners (fails with 0.8.0)
-        "jupyterhub @ git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub",
     ])
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,6 @@ def write_version_py():
 
 write_version_py()
 
-with open('requirements.txt', 'r') as REQUIREMENTS:
-    requirements = [
-        line.strip() for line in REQUIREMENTS.readlines()
-        if not line.startswith('#')
-    ]
-
 # Unfortunately RTD cannot install jupyterhub because jupyterhub needs bower,
 # and that is not available. We prevent the request for the unreleased jhub
 # by skipping it if we are on RTD
@@ -40,18 +34,27 @@ if on_rtd:
     # These are the dependencies of jupyterhub that we need to have in order
     # for our code to import on RTD.
     requirements = [
-        dep for dep in requirements if not dep.startswith("jupyterhub")]
-    requirements.extend([
+        "setuptools>=21.0",
+        "traitlets>=4.1",
+        "tornado>=4.3",
+        "requests>=2.10.0",
+        "escapism>=0.0.1",
+        "jupyter_client>=4.3.0",
+        "click>=6.6",
+        "tabulate>=0.7.5",
+        "oauthenticator>=0.5",
         "sqlalchemy>=1.0",
         # Pinning jinja2 requirements when building on RTD due to
         # regression when using old versions of sphinx<2
         # https://github.com/readthedocs/readthedocs.org/issues/9037
         "jinja2<3.1.0",
-    ])
+    ]
 else:
-    requirements.extend([
-        "jinja>=2.8",
-    ])
+    with open('requirements.txt', 'r') as REQUIREMENTS:
+        requirements = [
+            line.strip() for line in REQUIREMENTS.readlines()
+            if not line.startswith('#')
+        ]
 
 
 class install(_install):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ else:
     requirements.extend([
         "jinja>=2.8",
         # Pinned to jupyterhub 0.8.0.dev0 due to issues with spawners (fails with 0.8.0)
-        "git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub",
+        "jupyterhub @ git+http://github.com/jupyterhub/jupyterhub.git@2d1a45f0190059ef436c2f97dc8d6e391eb2d139#egg=jupyterhub",
     ])
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ write_version_py()
 
 with open('requirements.txt', 'r') as REQUIREMENTS:
     requirements = [
-        line for line in REQUIREMENTS.readlines() if not line.startswith('#')
+        line.strip() for line in REQUIREMENTS.readlines()
+        if not line.startswith('#')
     ]
 
 # Unfortunately RTD cannot install jupyterhub because jupyterhub needs bower,


### PR DESCRIPTION
Closes #599 

Applies a minimal solution of pinning `jinja2<3.1.0` when building on RTD and tidies up declaration of requirements between platforms.

In the long run we probably should be using later version of Sphinx on RTD, but this may require a larger number of changes.