### PR TITLE
Update `docker-py` 1.8 to `docker` 2.2

### DIFF
--- a/remoteappmanager/cli/remoteappdb/__main__.py
+++ b/remoteappmanager/cli/remoteappdb/__main__.py
@@ -74,7 +74,7 @@ def print_error(error):
 
 
 def get_docker_client():
-    """ Returns docker.client object using the local environment variables
+    """ Returns docker.APIClient object using the local environment variables
     """
     # dependencies of docker-py is optional for this script
     try:
@@ -93,7 +93,7 @@ def get_docker_client():
         print_error('docker client fails to connect.')
         raise exception
 
-    return client
+    return client.api
 
 
 def is_sqlitedb_url(db_url):

--- a/remoteappmanager/docker/async_docker_client.py
+++ b/remoteappmanager/docker/async_docker_client.py
@@ -29,7 +29,7 @@ class AsyncDockerClient:
 
         Note that the executor is a ThreadPoolExecutor with a single thread.
         """
-        self._sync_client = docker.Client(*args, **kwargs)
+        self._sync_client = docker.APIClient(*args, **kwargs)
 
     def __getattr__(self, attr):
         """Returns the docker client method, wrapped in an async execution

--- a/remoteappmanager/docker/container.py
+++ b/remoteappmanager/docker/container.py
@@ -75,12 +75,12 @@ class Container(HasTraits):
     @classmethod
     def from_docker_dict(cls, docker_dict):
         """Returns a Container object with the info given by a
-        docker Client.
+        docker APIClient.
 
         Parameters
         ----------
         docker_dict : dict
-            One item from the result of docker.Client.containers
+            One item from the result of docker.APIClient.containers
 
         Returns
         -------
@@ -89,7 +89,7 @@ class Container(HasTraits):
         Examples
         --------
         >>> # containers is a list of dict
-        >>> containers = docker.Client().containers()
+        >>> containers = docker.APIClient().containers()
 
         >>> Container.from_docker_dict(containers[0])
 

--- a/remoteappmanager/tests/test_file_config.py
+++ b/remoteappmanager/tests/test_file_config.py
@@ -186,5 +186,5 @@ class TestFileConfig(TempMixin, unittest.TestCase):
         config = FileConfig()
         docker_config = config.docker_config()
 
-        with contextlib.closing(docker.Client(**docker_config)) as client:
+        with contextlib.closing(docker.APIClient(**docker_config)) as client:
             self.assertIsNotNone(client.info())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 setuptools==21.0
 traitlets>=4.1
 tornado==5.1.1
-# Fix to 2.10.0 due to docker-py needs (fails with 2.11.1)
-requests==2.10.0
-# We want 1.8 because 1.10 uses API version 1.24 and the docker server
-# on ubuntu uses 1.23, so they don't like each other.
+# Fix to 2.11.1 due to docker-py needs
+requests==2.11.1
 docker==2.2
 escapism==0.0.1
 jupyterhub==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ jupyter_client>=4.3.0
 click==6.6
 tabulate==0.7.5
 tornadowebapi @ git+http://github.com/simphony/tornado-webapi.git@8b6846faae23657a04cf97ca5229ce8ea083d000#egg=tornadowebapi
-oauthenticator>=0.10.0
+oauthenticator==0.11.0
 jinja2>=2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tornado==5.1.1
 requests==2.10.0
 # We want 1.8 because 1.10 uses API version 1.24 and the docker server
 # on ubuntu uses 1.23, so they don't like each other.
-docker-py==1.8
+docker==2.2
 escapism==0.0.1
 jupyterhub==0.8.1
 jupyter_client>=4.3.0

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,6 @@ write_version_py()
 # Unfortunately RTD cannot install jupyterhub because jupyterhub needs bower,
 # and that is not available. We prevent the request for the unreleased jhub
 # by skipping it if we are on RTD
-# We also have problems with requests as docker-py wants <2.11 and RTD
-# provides 2.11.1
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:


### PR DESCRIPTION
Approaches #449

Updates `docker-py` package 1.8 to `docker` 2.2 (name change from 2.x series onwards) but still uses the low-level API