### PR TITLE
Bump `requests` to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 setuptools==21.0
 traitlets>=4.1
 tornado==5.1.1
-# Fix to 2.11.1 due to docker-py needs
-requests==2.11.1
+requests==2.20.0
 docker==2.2
 escapism==0.0.1
 jupyterhub==0.9.6

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if on_rtd:
         "setuptools>=21.0",
         "traitlets>=4.1",
         "tornado>=4.3",
-        "requests>=2.10.0",
+        "requests>=2.20.0",
         "escapism>=0.0.1",
         "jupyter_client>=4.3.0",
         "click>=6.6",


### PR DESCRIPTION
Targets https://github.com/simphony/simphony-remote/security/dependabot/1

Alternative to #547, including tidying up RTD deps

Have QC tested `requests==2.20.2` and `docker==2.2` running on Ubuntu 18.04 to confirm that both packages are compatible