### PR TITLE
Expose demo application policy options in config

### DIFF
--- a/jupyterhub/remoteappmanager_config.py
+++ b/jupyterhub/remoteappmanager_config.py
@@ -67,7 +67,7 @@
 # # User accounting
 #
 # auto_user_creation = True
-# demo_applications = ['my-demo-app']
+# demo_applications = {'my-demo-app': {'allow_home': True}}
 #
 # # ----------------
 # # Google Analytics

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -21,7 +21,7 @@ from remoteappmanager.services.reverse_proxy import ReverseProxy
 
 
 DEFAULT_POLICY_OPTIONS = {
-    "app_license": '',
+    "app_license": None,
     "allow_home": False,
     "allow_view": True,
     "volume": None,

--- a/remoteappmanager/base_application.py
+++ b/remoteappmanager/base_application.py
@@ -20,6 +20,15 @@ from remoteappmanager.services.hub import Hub
 from remoteappmanager.services.reverse_proxy import ReverseProxy
 
 
+DEFAULT_POLICY_OPTIONS = {
+    "app_license": '',
+    "allow_home": False,
+    "allow_view": True,
+    "volume": None,
+    "allow_startup_data": False
+}
+
+
 class BaseApplication(web.Application, LoggingMixin):
     """Base application provides the common infrastructure
     to our tornado applications.
@@ -255,14 +264,13 @@ class BaseApplication(web.Application, LoggingMixin):
         for application in self.db.list_applications():
             if application.image in self.file_config.demo_applications:
                 self.log.debug(f"Available image: {application.image}")
+                options = DEFAULT_POLICY_OPTIONS.copy()
+                options.update(
+                    self.file_config.demo_applications[application.image])
                 self.db.grant_access(
-                    application.image,
-                    user.name,
-                    '',
-                    False,
-                    True,
-                    None,
-                    True
+                    app_name=application.image,
+                    user_name=user.name,
+                    **options
                 )
 
     def _webapi_resources(self):

--- a/remoteappmanager/db/orm.py
+++ b/remoteappmanager/db/orm.py
@@ -315,6 +315,8 @@ class ORMDatabase(ABCDatabase):
         allow_common = False
         source = target = mode = None
 
+        app_license = app_license if app_license else None
+
         if volume is not None:
             allow_common = True
             source, target, mode = parse_volume_string(volume)
@@ -381,6 +383,8 @@ class ORMDatabase(ABCDatabase):
                       allow_home, allow_view, volume, allow_startup_data):
         allow_common = False
         source = target = mode = None
+
+        app_license = app_license if app_license else None
 
         if volume is not None:
             allow_common = True

--- a/remoteappmanager/file_config.py
+++ b/remoteappmanager/file_config.py
@@ -2,7 +2,7 @@ import os
 
 import tornado.options
 from docker import tls
-from traitlets import HasTraits, List, Int, Unicode, Bool, Dict
+from traitlets import HasTraits, Int, Unicode, Bool, Dict
 
 from remoteappmanager import paths
 from remoteappmanager.traitlets import set_traits_from_dict

--- a/remoteappmanager/file_config.py
+++ b/remoteappmanager/file_config.py
@@ -71,8 +71,12 @@ class FileConfig(HasTraits):
         help="The google analytics tracking id"
     )
 
-    #: Provide names of any default applications granted to users
-    demo_applications = List()
+    #: Provide details of default applications granted to users,
+    #: where keys are app names and values are dictionaries of
+    #: policy option overrides
+    demo_applications = Dict(
+        help="Details of default applications granted to all users."
+    )
 
     #: Whether or not to automatically create user accounts upon starting
     #: up the application if they do not already exist in the database

--- a/remoteappmanager/tests/mocking/dummy.py
+++ b/remoteappmanager/tests/mocking/dummy.py
@@ -132,6 +132,7 @@ class DummyDB(interfaces.ABCDatabase):
                      allow_home, allow_view, volume, allow_startup_data):
         app = self._get_application_id_by_name(app_name)
         user = self._get_user_id_by_name(user_name)
+        app_license = app_license if app_license else None
 
         source, target, mode = volume.split(':')
         policy = DummyDBApplicationPolicy(

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -111,7 +111,7 @@ class TestApplication(TempMixin,
         self.file_config.database_kwargs = {
             "url": "sqlite:///"+sqlite_file_path}
         self.file_config.demo_applications = {
-            'my-demo-app': {}
+            'my-demo-app': {'allow_home': True}
         }
         self.file_config.auto_user_creation = True
 
@@ -127,7 +127,7 @@ class TestApplication(TempMixin,
         self.assertEqual(app_account.application.image, 'my-demo-app')
         self.assertIsNone(
             app_account.application_policy.app_license)
-        self.assertFalse(
+        self.assertTrue(
             app_account.application_policy.allow_home)
         self.assertTrue(
             app_account.application_policy.allow_view)

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -122,7 +122,20 @@ class TestApplication(TempMixin,
         self.assertIsNotNone(app.user.account)
 
         user_apps = app.db.get_accounting_for_user(app.user.account)
-        self.assertEqual('my-demo-app', user_apps[0].application.image)
+        app_account = user_apps[0]
+        self.assertEqual(app_account.application.image, 'my-demo-app')
+        self.assertIsNone(
+            app_account.application_policy.app_license)
+        self.assertFalse(
+            app_account.application_policy.allow_home)
+        self.assertTrue(
+            app_account.application_policy.allow_view)
+        self.assertIsNone(
+            app_account.application_policy.volume_source)
+        self.assertIsNone(
+            app_account.application_policy.volume_target)
+        self.assertFalse(
+            app_account.application_policy.allow_startup_data)
 
     def test_start(self):
         with patch(

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -2,12 +2,13 @@ import os
 from unittest import mock
 from unittest.mock import patch
 
+from tornado import testing
+from traitlets.traitlets import TraitError
+
 from remoteappmanager.application import Application
 from remoteappmanager.db.tests import test_csv_db
 from remoteappmanager.tests import utils
 from remoteappmanager.tests.temp_mixin import TempMixin
-from tornado import testing
-from traitlets.traitlets import TraitError
 
 
 class DummyDB:

--- a/remoteappmanager/tests/test_application.py
+++ b/remoteappmanager/tests/test_application.py
@@ -109,7 +109,9 @@ class TestApplication(TempMixin,
             "remoteappmanager.db.orm.ORMDatabase")
         self.file_config.database_kwargs = {
             "url": "sqlite:///"+sqlite_file_path}
-        self.file_config.demo_applications = ['my-demo-app']
+        self.file_config.demo_applications = {
+            'my-demo-app': {}
+        }
         self.file_config.auto_user_creation = True
 
         app = Application(self.command_line_config,

--- a/remoteappmanager/tests/test_user.py
+++ b/remoteappmanager/tests/test_user.py
@@ -7,8 +7,7 @@ class TestUser(TestCase):
 
     def setUp(self):
         self.user = User(name='test-user',
-                         login_service='Basic',
-                         demo_applications=['some-image'])
+                         login_service='Basic')
 
     def test_init(self):
         self.assertEqual('test-user', self.user.name)


### PR DESCRIPTION
Closes #611

Follows suggestion in #611 and exposes demo application policy options as a dictionary in `remoteappmanager_config.py` 